### PR TITLE
Include safe function code in infra bundle

### DIFF
--- a/packages/esbuild-plugins/src/parsers/remove-unsafe-references.ts
+++ b/packages/esbuild-plugins/src/parsers/remove-unsafe-references.ts
@@ -1,0 +1,125 @@
+import ts from "typescript";
+
+export function removeUnsafeReferences(sourceText: string): string {
+  const sourceFile = ts.createSourceFile(
+    "file.ts",
+    sourceText,
+    ts.ScriptTarget.ES2015,
+    true,
+  );
+  const printer = ts.createPrinter();
+
+  let infraImports: Set<string> = new Set();
+
+  function transformer(context: ts.TransformationContext) {
+    return (node: ts.Node, isTopLevel: boolean = true): ts.Node => {
+      if (
+        ts.isImportDeclaration(node) &&
+        ts.isStringLiteral(node.moduleSpecifier)
+      ) {
+        const path = node.moduleSpecifier.text;
+
+        // todo: enable relative paths by resolving path to validate location
+        if (path.startsWith("infra/")) {
+          node.importClause?.namedBindings?.forEachChild((namedBinding) => {
+            if (ts.isImportSpecifier(namedBinding)) {
+              infraImports.add(namedBinding.name.text);
+            }
+          });
+          return node;
+        } else {
+          return ts.factory.createNotEmittedStatement(node);
+        }
+      }
+
+      if (
+        ts.isStatement(node) &&
+        containsUnsafeReferences(node, infraImports)
+      ) {
+        return ts.factory.createNotEmittedStatement(node);
+      }
+
+      return ts.visitEachChild(
+        node,
+        (child) => transformer(context)(child),
+        context,
+      );
+    };
+  }
+
+  const transformedSourceFile = ts.transform(sourceFile, [transformer])
+    .transformed[0];
+
+  return printer.printFile(transformedSourceFile as ts.SourceFile);
+}
+
+function containsUnsafeReferences(
+  node: ts.Node,
+  safeReferences: Set<string>,
+): boolean {
+  let hasUnsafeReference = false;
+
+  function visit(n: ts.Node, parent: ts.Node | undefined = undefined): void {
+    if (ts.isIdentifier(n)) {
+      if (isReference(n, parent) && !safeReferences.has(n.text)) {
+        hasUnsafeReference = true;
+      }
+    } else {
+      n.forEachChild((child) => visit(child, n));
+    }
+  }
+
+  visit(node);
+
+  return hasUnsafeReference;
+}
+
+function isReference(
+  node: ts.Identifier,
+  parent: ts.Node | undefined,
+): boolean {
+  if (!parent) {
+    return false;
+  }
+
+  if (ts.isTypeReferenceNode(parent)) {
+    return false;
+  }
+
+  if (ts.isTypeParameterDeclaration(parent) && parent.name === node) {
+    return false;
+  }
+
+  if (
+    (ts.isInterfaceDeclaration(parent) || ts.isTypeAliasDeclaration(parent)) &&
+    parent.name === node
+  ) {
+    return false;
+  }
+
+  if (ts.isPropertyAssignment(parent) && parent.name === node) {
+    return false;
+  }
+
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) {
+    return false;
+  }
+
+  if (ts.isMethodDeclaration(parent) && parent.name === node) {
+    return false;
+  }
+
+  if (ts.isParameter(parent) && parent.name === node) {
+    return false;
+  }
+
+  if (ts.isVariableDeclaration(parent) && parent.name === node) {
+    return false;
+  }
+
+  if (ts.isFunctionDeclaration(parent) && parent.name === node) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
Currently, infrastructure modules can safely import function modules (treating them as resources). This PR makes it possible for function modules to import infrastructure modules. 

Why is this necessary? As discussed in discussion #2, there are use cases where a function will need to be configured based upon some infrastructure concerns. For example, a lambda that calls out to DynamoDB needs to have a policy that grants access to the table. The best place to define this is in the lambda, where the developer can see what access is actually required. Even better would be to put type constraints on the Dynamo DB client based on the access that has been granted e.g. can only call putItem if putItem access has been granted to the lambda role.

To achieve this, some code in the function module will need to be evaluated when generating the orchestration graph. To make this safe, we can eliminate everything from the module, except that which is definitely safe to evaluate.

```ts
// this is safe to evaluate because it comes from an infra module
import { userTable } from "infra/tables.ts"; 

// runtime stuff, should not be evaluated at compile time
import { handle, json } from "@notation/aws/lambda.fn"; 

// definitely not safe!
fetch("https://example.com"); 

// safe – only contains references to an infra object
const userTableClient = userTable.createClient({
  allow: ["getItem", "putItem"],
});

// not safe
const userTableClient = userTable.client({
  allow: ["getItem", "putItem"],
  cheeky: handle,
});

// not safe
export const writeUser = handle.apiRequest(() => {
  const user = await userTableClient.get({
    id: "user-1",
  });
  return user;
});
```

The compiler does three things:
1. Checks if an import is coming from an infra module (some updates to the project structure will be required to enable this)
2. Marks those imports as safe references
3. Only keeps statements that contain identifiers that are definitely safe references

Because the heuristic is to opt-in safe code, and I have not covered every possible case, the resulting parser is quite aggressive. It will cull statements that are definitely safe. That's ok for now - the use cases will be limited.

This is a rough solution. It is not efficient, particularly as I didn't refactor the existing compiler transform, but it provides a reasonable foundation to build some interesting features.
