### PR TITLE
Improve eventBridge entry point API.

### DIFF
--- a/packages/aws/src/event-bridge/aws-conversions.ts
+++ b/packages/aws/src/event-bridge/aws-conversions.ts
@@ -1,0 +1,20 @@
+import { Schedule } from "./schedule";
+
+export const toAwsScheduleExpression = (schedule: Schedule): string => {
+  if (schedule.type === "rate") {
+    return `rate(${schedule.rate} ${schedule.unit})`;
+  } else if (schedule.type === "cron") {
+    return `cron(${schedule.cronExpression})`;
+  } else {
+    const dateTime = schedule.dateTime;
+    const humanBasedMonth = dateTime.getMonth() + 1;
+    const monthString =
+      humanBasedMonth >= 10 ? `${humanBasedMonth}` : `0${humanBasedMonth}`;
+    const dayString =
+      dateTime.getDate() >= 10
+        ? `${dateTime.getDate()}`
+        : `0${dateTime.getDate()}`;
+
+    return `at(${dateTime.getFullYear()}-${monthString})-${dayString}-${dateTime.toLocaleTimeString()}`;
+  }
+};

--- a/packages/aws/src/event-bridge/schedule.ts
+++ b/packages/aws/src/event-bridge/schedule.ts
@@ -18,7 +18,7 @@ export type OneTimeSchedule = {
 
 export type Schedule = RateSchedule | CronSchedule | OneTimeSchedule;
 
-export const rateSchedule = (rate: number, unit: RateUnit): Schedule => {
+export const rate = (rate: number, unit: RateUnit): Schedule => {
   return {
     type: "rate",
     rate: rate,
@@ -26,35 +26,16 @@ export const rateSchedule = (rate: number, unit: RateUnit): Schedule => {
   };
 };
 
-export const cronSchedule = (cronExpression: string): Schedule => {
+export const cron = (cronExpression: string): Schedule => {
   return {
     type: "cron",
     cronExpression: cronExpression,
   };
 };
 
-export const oneTimeSchedule = (dateTime: Date): Schedule => {
+export const once = (dateTime: Date): Schedule => {
   return {
     type: "once",
     dateTime: dateTime,
   };
-};
-
-export const toAwsScheduleExpression = (schedule: Schedule): string => {
-  if (schedule.type === "rate") {
-    return `rate(${schedule.rate} ${schedule.unit})`;
-  } else if (schedule.type === "cron") {
-    return `cron(${schedule.cronExpression})`;
-  } else {
-    const dateTime = schedule.dateTime;
-    const humanBasedMonth = dateTime.getMonth() + 1;
-    const monthString =
-      humanBasedMonth >= 10 ? `${humanBasedMonth}` : `0${humanBasedMonth}`;
-    const dayString =
-      dateTime.getDate() >= 10
-        ? `${dateTime.getDate()}`
-        : `0${dateTime.getDate()}`;
-
-    return `at(${dateTime.getFullYear()}-${monthString})-${dayString}-${dateTime.toLocaleTimeString()}`;
-  }
 };

--- a/test/compiler.test.app/infra/event-bridge.ts
+++ b/test/compiler.test.app/infra/event-bridge.ts
@@ -1,10 +1,8 @@
-import { eventBridgeSchedule, rateSchedule } from "@notation/aws/event-bridge";
+import * as eventBridge from "@notation/aws/event-bridge";
 import { exampleHandler2 } from "runtime/eventbridge/scheduleEvent.fn";
 
-eventBridgeSchedule(
-  {
-    ruleName: "Event-bridge-schedule-test",
-    schedule: rateSchedule(1, "minute"),
-  },
-  exampleHandler2,
-);
+eventBridge.schedule({
+  name: "Event-bridge-schedule-test",
+  schedule: eventBridge.rate(1, "minute"),
+  handler: exampleHandler2,
+});


### PR DESCRIPTION
This change brings the API for eventBridge closer to that seen in the code snippet on https://notation.dev by:

* Renaming 'ruleName' config option to 'name'
* Accepting schedule handler function in the config object passed in as the 'handler' field.
* Renamed the schedule builder functions (to 'rate', 'once', 'cron'.)

Additional changes:
* No longer export 'toAwsScheduleExpression' from the module as this is a notation helper function. It has been moved to its own file.

# Questions

* In the https://notation.dev snippet the *caller* names the module as 'eventBridge' on import. In this PR, it is exported as an object with this name. I like it being exported this way as I think it encourages the user to write something more readable as it's clear it's coming from the AWS eventBridge service. Do you have any thoughts on this?

# Testing

I manually tested these changes.