### PR TITLE
Coordinate concurrent reconciler state

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "@notation/reconciler": "workspace:*",
     "@notation/resource": "workspace:*",
     "@notation/state": "workspace:*",
+    "@notation/state-sqlite": "workspace:*",
     "deep-object-diff": "^1.1.9",
     "js-base64": "^3.7.7",
     "lodash-es": "^4.17.21",

--- a/packages/core/src/provisioner/operations/operation.create.ts
+++ b/packages/core/src/provisioner/operations/operation.create.ts
@@ -25,21 +25,17 @@ async function create(
 
     resource.setOutput({ ...resource.output, ...readResult });
 
-    await state.update(
-      resource.id,
-      {
-        id: resource.id,
-        groupId: resource.groupId,
-        groupType: resource.groupType,
-        type: resource.type,
-        lastOperation: "create",
-        lastOperationAt: new Date().toISOString(),
-        config: resource.config,
-        params: resource.toState(params),
-        output: resource.toState(resource.output),
-      },
-      0,
-    );
+    await state.update(resource.id, 0, {
+      id: resource.id,
+      groupId: resource.groupId,
+      groupType: resource.groupType,
+      type: resource.type,
+      lastOperation: "create",
+      lastOperationAt: new Date().toISOString(),
+      config: resource.config,
+      params: resource.toState(params),
+      output: resource.toState(resource.output),
+    });
   } catch (err: any) {
     const retryCondition =
       resource.retryLaterOnError &&

--- a/packages/core/src/provisioner/operations/operation.create.ts
+++ b/packages/core/src/provisioner/operations/operation.create.ts
@@ -25,17 +25,21 @@ async function create(
 
     resource.setOutput({ ...resource.output, ...readResult });
 
-    await state.update(resource.id, {
-      id: resource.id,
-      groupId: resource.groupId,
-      groupType: resource.groupType,
-      type: resource.type,
-      lastOperation: "create",
-      lastOperationAt: new Date().toISOString(),
-      config: resource.config,
-      params: resource.toState(params),
-      output: resource.toState(resource.output),
-    });
+    await state.update(
+      resource.id,
+      {
+        id: resource.id,
+        groupId: resource.groupId,
+        groupType: resource.groupType,
+        type: resource.type,
+        lastOperation: "create",
+        lastOperationAt: new Date().toISOString(),
+        config: resource.config,
+        params: resource.toState(params),
+        output: resource.toState(resource.output),
+      },
+      0,
+    );
   } catch (err: any) {
     const retryCondition =
       resource.retryLaterOnError &&

--- a/packages/core/src/provisioner/operations/operation.delete.ts
+++ b/packages/core/src/provisioner/operations/operation.delete.ts
@@ -6,6 +6,10 @@ export const deleteResource = operation("Destroying", delete_);
 
 async function delete_(opts: { resource: BaseResource; state: StateBackend }) {
   const { resource, state } = opts;
+  const stateNode = await state.get(resource.id);
+  if (!stateNode) {
+    throw new Error(`Missing state for ${resource.type} ${resource.id}`);
+  }
 
   try {
     await resource.delete(resource.key, resource.toState(resource.output));
@@ -27,5 +31,5 @@ async function delete_(opts: { resource: BaseResource; state: StateBackend }) {
     }
   }
 
-  await state.delete(resource.id);
+  await state.delete(resource.id, stateNode.rev);
 }

--- a/packages/core/src/provisioner/operations/operation.update.ts
+++ b/packages/core/src/provisioner/operations/operation.update.ts
@@ -11,6 +11,10 @@ async function update(opts: {
   patch: any;
 }): Promise<void> {
   const { resource, state, patch } = opts;
+  const stateNode = await state.get(resource.id);
+  if (!stateNode) {
+    throw new Error(`Missing state for ${resource.type} ${resource.id}`);
+  }
 
   if (!resource.update) {
     throw new Error(
@@ -31,10 +35,14 @@ async function update(opts: {
   const result = await readResource({ resource, state, quiet: true });
   resource.setOutput({ ...resource.output, ...result });
 
-  await state.update(resource.id, {
-    lastOperation: "update",
-    lastOperationAt: new Date().toISOString(),
-    params: resource.toState(params),
-    output: resource.toState(resource.output),
-  });
+  await state.update(
+    resource.id,
+    {
+      lastOperation: "update",
+      lastOperationAt: new Date().toISOString(),
+      params: resource.toState(params),
+      output: resource.toState(resource.output),
+    },
+    stateNode.rev,
+  );
 }

--- a/packages/core/src/provisioner/operations/operation.update.ts
+++ b/packages/core/src/provisioner/operations/operation.update.ts
@@ -35,14 +35,10 @@ async function update(opts: {
   const result = await readResource({ resource, state, quiet: true });
   resource.setOutput({ ...resource.output, ...result });
 
-  await state.update(
-    resource.id,
-    {
-      lastOperation: "update",
-      lastOperationAt: new Date().toISOString(),
-      params: resource.toState(params),
-      output: resource.toState(resource.output),
-    },
-    stateNode.rev,
-  );
+  await state.update(resource.id, stateNode.rev, {
+    lastOperation: "update",
+    lastOperationAt: new Date().toISOString(),
+    params: resource.toState(params),
+    output: resource.toState(resource.output),
+  });
 }

--- a/packages/core/src/provisioner/state-backend.ts
+++ b/packages/core/src/provisioner/state-backend.ts
@@ -1,5 +1,3 @@
-import { mkdirSync } from "node:fs";
-import path from "node:path";
 import { FileStateBackend, type StateBackend } from "@notation/state";
 import { SqliteStateBackend } from "@notation/state-sqlite";
 
@@ -12,10 +10,6 @@ export function resolveStatePath(): string {
 export function createDefaultStateBackend(): StateBackend {
   const statePath = resolveStatePath();
   if (statePath.endsWith(".db") || statePath.endsWith(".sqlite")) {
-    // FileStateBackend creates its directory lazily on first write, but the
-    // sqlite backend opens the database in its constructor, so the directory
-    // must exist up front.
-    mkdirSync(path.dirname(statePath), { recursive: true });
     return new SqliteStateBackend(statePath);
   }
   return new FileStateBackend(statePath);

--- a/packages/core/src/provisioner/state-backend.ts
+++ b/packages/core/src/provisioner/state-backend.ts
@@ -1,4 +1,7 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
 import { FileStateBackend, type StateBackend } from "@notation/state";
+import { SqliteStateBackend } from "@notation/state-sqlite";
 
 export const DEFAULT_STATE_PATH = "./.notation/state.json";
 
@@ -7,5 +10,13 @@ export function resolveStatePath(): string {
 }
 
 export function createDefaultStateBackend(): StateBackend {
-  return new FileStateBackend(resolveStatePath());
+  const statePath = resolveStatePath();
+  if (statePath.endsWith(".db") || statePath.endsWith(".sqlite")) {
+    // FileStateBackend creates its directory lazily on first write, but the
+    // sqlite backend opens the database in its constructor, so the directory
+    // must exist up front.
+    mkdirSync(path.dirname(statePath), { recursive: true });
+    return new SqliteStateBackend(statePath);
+  }
+  return new FileStateBackend(statePath);
 }

--- a/packages/core/test/provisioner/operation.create.test.ts
+++ b/packages/core/test/provisioner/operation.create.test.ts
@@ -31,6 +31,7 @@ describe("resource creation", () => {
       createResourceOperation(step, {
         resource: testResource,
         state: stateBackend,
+        expectedRev: 0,
       }),
     );
 

--- a/packages/core/test/provisioner/state-backend.test.ts
+++ b/packages/core/test/provisioner/state-backend.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FileStateBackend } from "@notation/state";
+import { SqliteStateBackend } from "@notation/state-sqlite";
+import { createDefaultStateBackend } from "src/provisioner/state-backend";
+
+describe("createDefaultStateBackend", () => {
+  let directory: string;
+  const originalStatePath = process.env.NOTATION_STATE_PATH;
+
+  beforeEach(() => {
+    directory = mkdtempSync(path.join(tmpdir(), "notation-state-"));
+  });
+
+  afterEach(() => {
+    if (originalStatePath === undefined) {
+      delete process.env.NOTATION_STATE_PATH;
+    } else {
+      process.env.NOTATION_STATE_PATH = originalStatePath;
+    }
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("uses the file backend for the default JSON path", () => {
+    delete process.env.NOTATION_STATE_PATH;
+
+    expect(createDefaultStateBackend()).toBeInstanceOf(FileStateBackend);
+  });
+
+  it("uses the sqlite backend for .db paths", () => {
+    process.env.NOTATION_STATE_PATH = path.join(directory, "state.db");
+
+    const backend = createDefaultStateBackend();
+    expect(backend).toBeInstanceOf(SqliteStateBackend);
+    (backend as SqliteStateBackend).close();
+  });
+
+  it("uses the sqlite backend for .sqlite paths", () => {
+    process.env.NOTATION_STATE_PATH = path.join(directory, "state.sqlite");
+
+    const backend = createDefaultStateBackend();
+    expect(backend).toBeInstanceOf(SqliteStateBackend);
+    (backend as SqliteStateBackend).close();
+  });
+
+  it("creates missing parent directories for sqlite paths", () => {
+    process.env.NOTATION_STATE_PATH = path.join(
+      directory,
+      ".notation",
+      "state.db",
+    );
+
+    const backend = createDefaultStateBackend();
+    expect(backend).toBeInstanceOf(SqliteStateBackend);
+    (backend as SqliteStateBackend).close();
+  });
+});

--- a/packages/reconciler/src/operations/operation.create.ts
+++ b/packages/reconciler/src/operations/operation.create.ts
@@ -60,23 +60,17 @@ export async function* createResourceOperation(
     });
 
     yield* step.run("create:persist-state", async () => {
-      // expectedRev 0 asserts the record is still absent, so two first-time
-      // deploys of the same resource cannot both persist.
-      await params.state.update(
-        params.resource.id,
-        {
-          id: params.resource.id,
-          groupId: params.resource.groupId,
-          groupType: params.resource.groupType,
-          type: params.resource.type,
-          lastOperation: "create",
-          lastOperationAt: new Date().toISOString(),
-          config: params.resource.config,
-          params: params.resource.toState(resourceParams),
-          output: params.resource.toState(params.resource.output),
-        },
-        params.expectedRev,
-      );
+      await params.state.update(params.resource.id, params.expectedRev, {
+        id: params.resource.id,
+        groupId: params.resource.groupId,
+        groupType: params.resource.groupType,
+        type: params.resource.type,
+        lastOperation: "create",
+        lastOperationAt: new Date().toISOString(),
+        config: params.resource.config,
+        params: params.resource.toState(resourceParams),
+        output: params.resource.toState(params.resource.output),
+      });
     });
 
     await emitLifecycleEvent(params, "create", "success");

--- a/packages/reconciler/src/operations/operation.create.ts
+++ b/packages/reconciler/src/operations/operation.create.ts
@@ -60,17 +60,23 @@ export async function* createResourceOperation(
     });
 
     yield* step.run("create:persist-state", async () => {
-      await params.state.update(params.resource.id, {
-        id: params.resource.id,
-        groupId: params.resource.groupId,
-        groupType: params.resource.groupType,
-        type: params.resource.type,
-        lastOperation: "create",
-        lastOperationAt: new Date().toISOString(),
-        config: params.resource.config,
-        params: params.resource.toState(resourceParams),
-        output: params.resource.toState(params.resource.output),
-      });
+      // expectedRev 0 asserts the record is still absent, so two first-time
+      // deploys of the same resource cannot both persist.
+      await params.state.update(
+        params.resource.id,
+        {
+          id: params.resource.id,
+          groupId: params.resource.groupId,
+          groupType: params.resource.groupType,
+          type: params.resource.type,
+          lastOperation: "create",
+          lastOperationAt: new Date().toISOString(),
+          config: params.resource.config,
+          params: params.resource.toState(resourceParams),
+          output: params.resource.toState(params.resource.output),
+        },
+        params.expectedRev,
+      );
     });
 
     await emitLifecycleEvent(params, "create", "success");

--- a/packages/reconciler/src/operations/operation.delete.ts
+++ b/packages/reconciler/src/operations/operation.delete.ts
@@ -49,7 +49,7 @@ export async function* deleteResourceOperation(
     }
 
     yield* step.run("delete:persist-state", () =>
-      params.state.delete(params.resource.id),
+      params.state.delete(params.resource.id, params.expectedRev),
     );
 
     await emitLifecycleEvent(params, "delete", "success");

--- a/packages/reconciler/src/operations/operation.types.ts
+++ b/packages/reconciler/src/operations/operation.types.ts
@@ -1,14 +1,14 @@
-import type { BaseResource, ErrorMatcher, ResourceType } from "@notation/resource";
+import type {
+  BaseResource,
+  ErrorMatcher,
+  ResourceType,
+} from "@notation/resource";
 import type { State } from "@notation/state";
 
 export type OperationName = "create" | "read" | "update" | "delete";
 
 export type OperationLifecycleStatus =
-  | "start"
-  | "success"
-  | "error"
-  | "skip"
-  | "dry-run";
+  "start" | "success" | "error" | "skip" | "dry-run";
 
 export type OperationLifecycleEvent = {
   level: "info" | "error";
@@ -59,15 +59,20 @@ export type ResourceOperationBaseParams = {
   readPollOptions?: PollOptions;
 };
 
-export type CreateResourceParams = ResourceOperationBaseParams;
+export type CreateResourceParams = ResourceOperationBaseParams & {
+  expectedRev: number;
+};
 
 export type ReadResourceParams = ResourceOperationBaseParams;
 
 export type UpdateResourceParams = ResourceOperationBaseParams & {
   patch: Record<string, unknown>;
+  expectedRev: number;
 };
 
-export type DeleteResourceParams = ResourceOperationBaseParams;
+export type DeleteResourceParams = ResourceOperationBaseParams & {
+  expectedRev: number;
+};
 
 export const DEFAULT_RETRY_OPTIONS: PollOptions = {
   maxAttempts: 10,

--- a/packages/reconciler/src/operations/operation.update.ts
+++ b/packages/reconciler/src/operations/operation.update.ts
@@ -71,8 +71,13 @@ export async function* updateResourceOperation(
 
     yield* step.run("update:persist-state", async () => {
       await params.state.update(params.resource.id, params.expectedRev, {
+        id: params.resource.id,
+        groupId: params.resource.groupId,
+        groupType: params.resource.groupType,
+        type: params.resource.type,
         lastOperation: "update",
         lastOperationAt: new Date().toISOString(),
+        config: params.resource.config,
         params: params.resource.toState(resourceParams),
         output: params.resource.toState(params.resource.output),
       });

--- a/packages/reconciler/src/operations/operation.update.ts
+++ b/packages/reconciler/src/operations/operation.update.ts
@@ -70,16 +70,12 @@ export async function* updateResourceOperation(
     });
 
     yield* step.run("update:persist-state", async () => {
-      await params.state.update(
-        params.resource.id,
-        {
-          lastOperation: "update",
-          lastOperationAt: new Date().toISOString(),
-          params: params.resource.toState(resourceParams),
-          output: params.resource.toState(params.resource.output),
-        },
-        params.expectedRev,
-      );
+      await params.state.update(params.resource.id, params.expectedRev, {
+        lastOperation: "update",
+        lastOperationAt: new Date().toISOString(),
+        params: params.resource.toState(resourceParams),
+        output: params.resource.toState(params.resource.output),
+      });
     });
 
     await emitLifecycleEvent(params, "update", "success");

--- a/packages/reconciler/src/operations/operation.update.ts
+++ b/packages/reconciler/src/operations/operation.update.ts
@@ -70,12 +70,16 @@ export async function* updateResourceOperation(
     });
 
     yield* step.run("update:persist-state", async () => {
-      await params.state.update(params.resource.id, {
-        lastOperation: "update",
-        lastOperationAt: new Date().toISOString(),
-        params: params.resource.toState(resourceParams),
-        output: params.resource.toState(params.resource.output),
-      });
+      await params.state.update(
+        params.resource.id,
+        {
+          lastOperation: "update",
+          lastOperationAt: new Date().toISOString(),
+          params: params.resource.toState(resourceParams),
+          output: params.resource.toState(params.resource.output),
+        },
+        params.expectedRev,
+      );
     });
 
     await emitLifecycleEvent(params, "update", "success");

--- a/packages/reconciler/src/plan.ts
+++ b/packages/reconciler/src/plan.ts
@@ -43,7 +43,11 @@ export type ResourceAction =
   | { decision: "noop" }
   | { decision: "drift-recreate" }
   | { decision: "update"; patch: Record<string, unknown>; diff: PlanDiff }
-  | { decision: "drift-update"; patch: Record<string, unknown>; diff: PlanDiff };
+  | {
+      decision: "drift-update";
+      patch: Record<string, unknown>;
+      diff: PlanDiff;
+    };
 
 export function decideAction(opts: {
   resource: BaseResource;
@@ -52,17 +56,50 @@ export function decideAction(opts: {
   driftRead?: DriftRead;
 }): ResourceAction {
   const { resource, stateNode, params, driftRead } = opts;
-
-  if (!stateNode) {
-    return { decision: "create" };
-  }
-
-  const previousComparable = resource.toComparable(stateNode.params);
   const desiredComparable = resource.toComparable(params ?? {});
+  const previousComparable = resource.toComparable(stateNode?.params ?? {});
   const localPatch = diff(previousComparable, desiredComparable) as Record<
     string,
     unknown
   >;
+
+  if (driftRead) {
+    if (driftRead.status === "not-found") {
+      return { decision: stateNode ? "drift-recreate" : "create" };
+    }
+
+    const remoteComparable = resource.toComparable(driftRead.output);
+    const remotePatch = diff(remoteComparable, desiredComparable) as Record<
+      string,
+      unknown
+    >;
+
+    if (Object.keys(remotePatch).length === 0) {
+      return { decision: "noop" };
+    }
+
+    const remoteDetailedDiff = detailedDiff(
+      remoteComparable,
+      desiredComparable,
+    );
+    if (!stateNode || Object.keys(localPatch).length > 0) {
+      return {
+        decision: "update",
+        patch: remotePatch,
+        diff: toPlanDiff(remoteDetailedDiff),
+      };
+    }
+
+    return {
+      decision: "drift-update",
+      patch: remotePatch,
+      diff: toPlanDiff(remoteDetailedDiff),
+    };
+  }
+
+  if (!stateNode) {
+    return { decision: "create" };
+  }
 
   if (Object.keys(localPatch).length > 0) {
     return {
@@ -72,32 +109,7 @@ export function decideAction(opts: {
     };
   }
 
-  if (!driftRead) {
-    return { decision: "noop" };
-  }
-
-  if (driftRead.status === "not-found") {
-    return { decision: "drift-recreate" };
-  }
-
-  const remoteDetailedDiff = detailedDiff(
-    resource.toComparable(driftRead.output),
-    resource.toComparable(stateNode.output),
-  );
-  const remotePatch = {
-    ...remoteDetailedDiff.updated,
-    ...remoteDetailedDiff.added,
-  } as Record<string, unknown>;
-
-  if (Object.keys(remotePatch).length === 0) {
-    return { decision: "noop" };
-  }
-
-  return {
-    decision: "drift-update",
-    patch: remotePatch,
-    diff: toPlanDiff(remoteDetailedDiff),
-  };
+  return { decision: "noop" };
 }
 
 export async function resolvePlanParams(

--- a/packages/reconciler/src/reconciler.ts
+++ b/packages/reconciler/src/reconciler.ts
@@ -318,11 +318,7 @@ export class Reconciler {
         return;
       case "update":
       case "drift-update":
-        if (!stateNode) {
-          throw new Error(
-            `Cannot ${action.decision} ${resource.id} without state`,
-          );
-        }
+        // decideAction only returns update decisions for an existing stateNode
         await runOperation(
           updateResourceOperation(this.#stepRunner, {
             resource,
@@ -332,7 +328,7 @@ export class Reconciler {
             emit: this.#emit,
             retryOptions: this.#retryOptions,
             readPollOptions: this.#readPollOptions,
-            expectedRev: stateNode.rev,
+            expectedRev: stateNode!.rev,
           }),
         );
         return;

--- a/packages/reconciler/src/reconciler.ts
+++ b/packages/reconciler/src/reconciler.ts
@@ -204,8 +204,8 @@ export class Reconciler {
     driftDetection: boolean,
   ) {
     await this.#withMutationLease(resource.id, () =>
-      this.#retryOnRevConflict(() =>
-        this.#deployResourceOnce(resource, dryRun, driftDetection),
+      this.#retryOnRevConflict((conflict) =>
+        this.#deployResourceOnce(resource, dryRun, driftDetection, conflict),
       ),
     );
   }
@@ -246,18 +246,18 @@ export class Reconciler {
     }
   }
 
-  /**
-   * A RevConflict means state moved between our read and our write. Each
-   * attempt re-reads state and re-decides, so the retried operation acts on
-   * the record as it now is (possibly deciding to do nothing).
-   */
-  async #retryOnRevConflict(fn: () => Promise<void>) {
+  async #retryOnRevConflict(fn: (conflict?: RevConflict) => Promise<void>) {
+    let conflict: RevConflict | undefined;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
-        await fn();
+        await fn(conflict);
         return;
       } catch (error) {
         if (!(error instanceof RevConflict) || attempt === 2) throw error;
+        // Re-throwing the conflict supplied for recovery means the resource
+        // cannot be recovered safely (for example, it has no read operation).
+        if (error === conflict) throw error;
+        conflict = error;
       }
     }
   }
@@ -266,7 +266,13 @@ export class Reconciler {
     resource: BaseResource,
     dryRun: boolean,
     driftDetection: boolean,
+    conflict?: RevConflict,
   ) {
+    if (conflict) {
+      await this.#recoverDeployResource(resource, dryRun, conflict);
+      return;
+    }
+
     const stateNode = await this.#state.get(resource.id);
 
     let action: ResourceAction;
@@ -333,6 +339,81 @@ export class Reconciler {
         );
         return;
       case "noop":
+        return;
+    }
+  }
+
+  async #recoverDeployResource(
+    resource: BaseResource,
+    dryRun: boolean,
+    conflict: RevConflict,
+  ) {
+    if (!resource.read) throw conflict;
+
+    const stateNode = await this.#state.get(resource.id);
+    if (stateNode) resource.setOutput(stateNode.output);
+
+    const params = await resource.getParams();
+    const remote = await this.#readForDrift(resource);
+    const action = decideAction({
+      resource,
+      stateNode,
+      params,
+      driftRead: remote,
+    });
+    if (remote.status === "found") resource.setOutput(remote.output);
+
+    await this.#emit?.({
+      level: "info",
+      event: "reconciler.deploy.decision",
+      resourceId: resource.id,
+      resourceType: resource.type,
+      decision: action.decision,
+    });
+
+    switch (action.decision) {
+      case "create":
+      case "drift-recreate":
+        await runOperation(
+          createResourceOperation(this.#stepRunner, {
+            resource,
+            state: this.#state,
+            dryRun,
+            emit: this.#emit,
+            retryOptions: this.#retryOptions,
+            readPollOptions: this.#readPollOptions,
+            expectedRev: stateNode?.rev ?? 0,
+          }),
+        );
+        return;
+      case "update":
+      case "drift-update":
+        await runOperation(
+          updateResourceOperation(this.#stepRunner, {
+            resource,
+            state: this.#state,
+            patch: action.patch,
+            dryRun,
+            emit: this.#emit,
+            retryOptions: this.#retryOptions,
+            readPollOptions: this.#readPollOptions,
+            expectedRev: stateNode?.rev ?? 0,
+          }),
+        );
+        return;
+      case "noop":
+        if (dryRun) return;
+        await this.#state.update(resource.id, stateNode?.rev ?? 0, {
+          id: resource.id,
+          groupId: resource.groupId,
+          groupType: resource.groupType,
+          type: resource.type,
+          lastOperation: "drift",
+          lastOperationAt: new Date().toISOString(),
+          config: resource.config,
+          params: resource.toState(params),
+          output: resource.toState(resource.output),
+        });
         return;
     }
   }
@@ -411,7 +492,7 @@ export class Reconciler {
         }
 
         await this.#withMutationLease(stateNode.id, () =>
-          this.#retryOnRevConflict(async () => {
+          this.#retryOnRevConflict(async (conflict) => {
             const currentNode = await this.#state.get(stateNode.id);
             if (!currentNode) return;
 
@@ -420,15 +501,11 @@ export class Reconciler {
               currentNode,
             );
 
-            await runOperation(
-              deleteResourceOperation(this.#stepRunner, {
-                resource: orphanResource,
-                state: this.#state,
-                dryRun,
-                emit: this.#emit,
-                retryOptions: this.#retryOptions,
-                expectedRev: currentNode.rev,
-              }),
+            await this.#deleteResourceOnce(
+              orphanResource,
+              currentNode,
+              dryRun,
+              conflict,
             );
           }),
         );
@@ -438,24 +515,43 @@ export class Reconciler {
 
   async #destroyResource(resource: BaseResource, dryRun: boolean) {
     await this.#withMutationLease(resource.id, () =>
-      this.#retryOnRevConflict(async () => {
+      this.#retryOnRevConflict(async (conflict) => {
         const stateNode = await this.#state.get(resource.id);
         if (!stateNode) {
           return;
         }
 
         resource.setOutput(stateNode.output);
+        await this.#deleteResourceOnce(resource, stateNode, dryRun, conflict);
+      }),
+    );
+  }
 
-        await runOperation(
-          deleteResourceOperation(this.#stepRunner, {
-            resource,
-            state: this.#state,
-            dryRun,
-            emit: this.#emit,
-            retryOptions: this.#retryOptions,
-            expectedRev: stateNode.rev,
-          }),
-        );
+  async #deleteResourceOnce(
+    resource: BaseResource,
+    stateNode: StateNode,
+    dryRun: boolean,
+    conflict?: RevConflict,
+  ) {
+    if (conflict) {
+      if (!resource.read) throw conflict;
+
+      const remote = await this.#readForDrift(resource);
+      if (remote.status === "not-found") {
+        if (!dryRun) await this.#state.delete(resource.id, stateNode.rev);
+        return;
+      }
+      resource.setOutput(remote.output);
+    }
+
+    await runOperation(
+      deleteResourceOperation(this.#stepRunner, {
+        resource,
+        state: this.#state,
+        dryRun,
+        emit: this.#emit,
+        retryOptions: this.#retryOptions,
+        expectedRev: stateNode.rev,
       }),
     );
   }

--- a/packages/reconciler/src/reconciler.ts
+++ b/packages/reconciler/src/reconciler.ts
@@ -1,6 +1,7 @@
 import type { BaseResource, ResourceType } from "@notation/resource";
-import type { State, StateNode } from "@notation/state";
+import { RevConflict, type State, type StateNode } from "@notation/state";
 import { RetryableError } from "yieldstar";
+import { setTimeout as sleep } from "node:timers/promises";
 import { buildResourceDepthLevels } from "./dependency-graph";
 import {
   decideAction,
@@ -55,7 +56,10 @@ export type ReconcilerEventEmitter = (
   event: ReconcilerEvent,
 ) => void | Promise<void>;
 
-export type ReconcilerState = Pick<State, "get" | "update" | "delete" | "values">;
+export type ReconcilerState = Pick<
+  State,
+  "get" | "update" | "delete" | "values" | "lease"
+>;
 
 export type ReconcilerOptions = {
   state: ReconcilerState;
@@ -65,6 +69,7 @@ export type ReconcilerOptions = {
   emit?: ReconcilerEventEmitter;
   retryOptions?: PollOptions;
   readPollOptions?: PollOptions;
+  mutationLeaseTtl?: number;
 };
 
 export type DeployOptions = {
@@ -92,6 +97,7 @@ export class Reconciler {
   readonly #emit?: ReconcilerEventEmitter;
   readonly #retryOptions?: PollOptions;
   readonly #readPollOptions?: PollOptions;
+  readonly #mutationLeaseTtl: number;
   readonly #stepRunner: StepRunner;
 
   constructor(opts: ReconcilerOptions) {
@@ -102,18 +108,26 @@ export class Reconciler {
     this.#emit = opts.emit;
     this.#retryOptions = opts.retryOptions;
     this.#readPollOptions = opts.readPollOptions;
+    this.#mutationLeaseTtl = opts.mutationLeaseTtl ?? 30_000;
     this.#stepRunner = createStepRunner();
   }
 
-  async deploy(resources: BaseResource[], opts: DeployOptions = {}): Promise<void> {
+  async deploy(
+    resources: BaseResource[],
+    opts: DeployOptions = {},
+  ): Promise<void> {
     const dryRun = opts.dryRun ?? this.#defaultDryRun;
     const driftDetection = opts.driftDetection ?? this.#defaultDriftDetection;
-    const resourceById = new Map(resources.map((resource) => [resource.id, resource]));
+    const resourceById = new Map(
+      resources.map((resource) => [resource.id, resource]),
+    );
 
     const dependencyLevels = buildResourceDepthLevels(resources);
     for (const level of dependencyLevels) {
       await Promise.all(
-        level.map((resource) => this.#deployResource(resource, dryRun, driftDetection)),
+        level.map((resource) =>
+          this.#deployResource(resource, dryRun, driftDetection),
+        ),
       );
     }
 
@@ -122,7 +136,9 @@ export class Reconciler {
 
   async plan(resources: BaseResource[], opts: PlanOptions = {}): Promise<Plan> {
     const driftDetection = opts.driftDetection ?? this.#defaultDriftDetection;
-    const resourceById = new Map(resources.map((resource) => [resource.id, resource]));
+    const resourceById = new Map(
+      resources.map((resource) => [resource.id, resource]),
+    );
     const nodes: PlanNode[] = [];
 
     const dependencyLevels = buildResourceDepthLevels(resources);
@@ -151,24 +167,102 @@ export class Reconciler {
     };
   }
 
-  async destroy(resources: BaseResource[], opts: DestroyOptions = {}): Promise<void> {
+  async destroy(
+    resources: BaseResource[],
+    opts: DestroyOptions = {},
+  ): Promise<void> {
     const dryRun = opts.dryRun ?? this.#defaultDryRun;
     const dependencyLevels = buildResourceDepthLevels(resources);
 
-    for (let levelIndex = dependencyLevels.length - 1; levelIndex >= 0; levelIndex -= 1) {
+    for (
+      let levelIndex = dependencyLevels.length - 1;
+      levelIndex >= 0;
+      levelIndex -= 1
+    ) {
       const level = dependencyLevels[levelIndex]!;
-      await Promise.all(level.map((resource) => this.#destroyResource(resource, dryRun)));
+      await Promise.all(
+        level.map((resource) => this.#destroyResource(resource, dryRun)),
+      );
     }
   }
 
-  async refresh(resources: BaseResource[], opts: RefreshOptions = {}): Promise<void> {
+  async refresh(
+    resources: BaseResource[],
+    opts: RefreshOptions = {},
+  ): Promise<void> {
     const dryRun = opts.dryRun ?? this.#defaultDryRun;
-    const resourceById = new Map(resources.map((resource) => [resource.id, resource]));
+    const resourceById = new Map(
+      resources.map((resource) => [resource.id, resource]),
+    );
 
     await this.#deleteOrphans(resources, resourceById, dryRun, "refresh");
   }
 
   async #deployResource(
+    resource: BaseResource,
+    dryRun: boolean,
+    driftDetection: boolean,
+  ) {
+    await this.#withMutationLease(resource.id, () =>
+      this.#retryOnRevConflict(() =>
+        this.#deployResourceOnce(resource, dryRun, driftDetection),
+      ),
+    );
+  }
+
+  async #withMutationLease<T>(resourceId: string, fn: () => Promise<T>) {
+    return this.#withLease(`reconciler:resource:${resourceId}`, fn);
+  }
+
+  async #withLease<T>(scope: string, fn: () => Promise<T>): Promise<T> {
+    const lease = await this.#state.lease(scope, this.#mutationLeaseTtl);
+    const controller = new AbortController();
+    let renewalError: unknown;
+    const heartbeat = (async () => {
+      try {
+        while (!controller.signal.aborted) {
+          await sleep(
+            Math.max(1, Math.floor(this.#mutationLeaseTtl / 3)),
+            undefined,
+            {
+              signal: controller.signal,
+            },
+          );
+          await lease.renew(this.#mutationLeaseTtl);
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) renewalError = error;
+      }
+    })();
+
+    try {
+      const result = await fn();
+      if (renewalError) throw renewalError;
+      return result;
+    } finally {
+      controller.abort();
+      await heartbeat;
+      await lease.release();
+    }
+  }
+
+  /**
+   * A RevConflict means state moved between our read and our write. Each
+   * attempt re-reads state and re-decides, so the retried operation acts on
+   * the record as it now is (possibly deciding to do nothing).
+   */
+  async #retryOnRevConflict(fn: () => Promise<void>) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await fn();
+        return;
+      } catch (error) {
+        if (!(error instanceof RevConflict) || attempt === 2) throw error;
+      }
+    }
+  }
+
+  async #deployResourceOnce(
     resource: BaseResource,
     dryRun: boolean,
     driftDetection: boolean,
@@ -218,11 +312,17 @@ export class Reconciler {
             emit: this.#emit,
             retryOptions: this.#retryOptions,
             readPollOptions: this.#readPollOptions,
+            expectedRev: stateNode?.rev ?? 0,
           }),
         );
         return;
       case "update":
       case "drift-update":
+        if (!stateNode) {
+          throw new Error(
+            `Cannot ${action.decision} ${resource.id} without state`,
+          );
+        }
         await runOperation(
           updateResourceOperation(this.#stepRunner, {
             resource,
@@ -232,6 +332,7 @@ export class Reconciler {
             emit: this.#emit,
             retryOptions: this.#retryOptions,
             readPollOptions: this.#readPollOptions,
+            expectedRev: stateNode.rev,
           }),
         );
         return;
@@ -291,61 +392,82 @@ export class Reconciler {
     dryRun: boolean,
     workflow: "deploy" | "refresh",
   ) {
-    const stateNodes = await this.#state.values();
-    const registry = this.#registry ?? createResourceRegistryFromResources(resources);
+    await this.#withLease("reconciler:orphan-deletion", async () => {
+      const stateNodes = await this.#state.values();
+      const registry =
+        this.#registry ?? createResourceRegistryFromResources(resources);
 
-    for (const stateNode of stateNodes) {
-      if (resourceById.has(stateNode.id)) continue;
+      for (const stateNode of stateNodes) {
+        if (resourceById.has(stateNode.id)) continue;
 
-      const stateNodeResourceType = stateNode.type as ResourceType;
+        const stateNodeResourceType = stateNode.type as ResourceType;
 
-      const Resource = resolveResourceClass(registry, stateNodeResourceType);
-      if (!Resource) {
-        await this.#emit?.(
-          createMissingResourceRegistryMatchWarningEvent({
-            workflow,
-            resourceId: stateNode.id,
-            resourceType: stateNodeResourceType,
+        const Resource = resolveResourceClass(registry, stateNodeResourceType);
+        if (!Resource) {
+          await this.#emit?.(
+            createMissingResourceRegistryMatchWarningEvent({
+              workflow,
+              resourceId: stateNode.id,
+              resourceType: stateNodeResourceType,
+            }),
+          );
+          continue;
+        }
+
+        await this.#withMutationLease(stateNode.id, () =>
+          this.#retryOnRevConflict(async () => {
+            const currentNode = await this.#state.get(stateNode.id);
+            if (!currentNode) return;
+
+            const orphanResource = hydrateResourceFromState(
+              Resource,
+              currentNode,
+            );
+
+            await runOperation(
+              deleteResourceOperation(this.#stepRunner, {
+                resource: orphanResource,
+                state: this.#state,
+                dryRun,
+                emit: this.#emit,
+                retryOptions: this.#retryOptions,
+                expectedRev: currentNode.rev,
+              }),
+            );
           }),
         );
-        continue;
       }
-
-      const orphanResource = hydrateResourceFromState(Resource, stateNode);
-
-      await runOperation(
-        deleteResourceOperation(this.#stepRunner, {
-          resource: orphanResource,
-          state: this.#state,
-          dryRun,
-          emit: this.#emit,
-          retryOptions: this.#retryOptions,
-        }),
-      );
-    }
+    });
   }
 
   async #destroyResource(resource: BaseResource, dryRun: boolean) {
-    const stateNode = await this.#state.get(resource.id);
-    if (!stateNode) {
-      return;
-    }
+    await this.#withMutationLease(resource.id, () =>
+      this.#retryOnRevConflict(async () => {
+        const stateNode = await this.#state.get(resource.id);
+        if (!stateNode) {
+          return;
+        }
 
-    resource.setOutput(stateNode.output);
+        resource.setOutput(stateNode.output);
 
-    await runOperation(
-      deleteResourceOperation(this.#stepRunner, {
-        resource,
-        state: this.#state,
-        dryRun,
-        emit: this.#emit,
-        retryOptions: this.#retryOptions,
+        await runOperation(
+          deleteResourceOperation(this.#stepRunner, {
+            resource,
+            state: this.#state,
+            dryRun,
+            emit: this.#emit,
+            retryOptions: this.#retryOptions,
+            expectedRev: stateNode.rev,
+          }),
+        );
       }),
     );
   }
 }
 
-export async function runOperation<T>(operation: AsyncGenerator<unknown, T, unknown>) {
+export async function runOperation<T>(
+  operation: AsyncGenerator<unknown, T, unknown>,
+) {
   let next = await operation.next();
   while (!next.done) {
     next = await operation.next();
@@ -354,7 +476,10 @@ export async function runOperation<T>(operation: AsyncGenerator<unknown, T, unkn
 }
 
 function hydrateResourceFromState(
-  Resource: new (opts: { id: string; config: Record<string, unknown> }) => BaseResource,
+  Resource: new (opts: {
+    id: string;
+    config: Record<string, unknown>;
+  }) => BaseResource,
   stateNode: StateNode,
 ): BaseResource {
   const resource = new Resource({
@@ -372,8 +497,7 @@ export function createStepRunner(): StepRunner {
       arg2?: () => T | Promise<T>,
     ): AsyncGenerator<unknown, T, unknown> {
       const fn = (typeof arg1 === "string" ? arg2 : arg1) as
-        | (() => T | Promise<T>)
-        | undefined;
+        (() => T | Promise<T>) | undefined;
 
       if (!fn) {
         throw new Error("Missing run function");
@@ -396,8 +520,7 @@ export function createStepRunner(): StepRunner {
     ): AsyncGenerator<unknown, void, unknown> {
       const opts = (typeof arg1 === "string" ? arg2 : arg1) as PollOptions;
       const predicate = (typeof arg1 === "string" ? arg3 : arg2) as
-        | (() => boolean | Promise<boolean>)
-        | undefined;
+        (() => boolean | Promise<boolean>) | undefined;
 
       if (!predicate) {
         throw new Error("Missing poll predicate");

--- a/packages/reconciler/test/operation.workflows.test.ts
+++ b/packages/reconciler/test/operation.workflows.test.ts
@@ -112,6 +112,7 @@ describe("operation workflows", () => {
       createResourceOperation(step, {
         resource: testResource,
         state,
+        expectedRev: 0,
         emit: async (event) => {
           events.push(event);
         },
@@ -211,13 +212,14 @@ describe("operation workflows", () => {
       deleteResourceOperation(step, {
         resource: testResource,
         state,
+        expectedRev: 1,
         emit: async (event) => {
           events.push(event);
         },
       }),
     );
 
-    expect(state.delete).toHaveBeenCalledWith("test-delete");
+    expect(state.delete).toHaveBeenCalledWith("test-delete", 1);
     expect(events.map((event) => event.status)).toEqual([
       "start",
       "skip",
@@ -257,6 +259,7 @@ describe("operation workflows", () => {
         deleteResourceOperation(step, {
           resource: testResource,
           state,
+          expectedRev: 1,
         }),
       ),
     ).rejects.toMatchObject({ name: "DifferentError", message: "still exists" });
@@ -291,6 +294,7 @@ describe("operation workflows", () => {
         createResourceOperation(step, {
           resource: testResource,
           state,
+          expectedRev: 0,
           emit: async (event) => {
             events.push(event);
           },

--- a/packages/reconciler/test/reconciler.deploy.test.ts
+++ b/packages/reconciler/test/reconciler.deploy.test.ts
@@ -1,30 +1,71 @@
 import { describe, expect, it, vi } from "vitest";
 import { resource } from "@notation/resource";
-import type { StateNode } from "@notation/state";
+import {
+  LeaseConflict,
+  MemoryStateBackend,
+  RevConflict,
+  type StateNode,
+} from "@notation/state";
 import { Reconciler, createResourceRegistry } from "../src";
 
-function createMemoryState(initial: Record<string, StateNode> = {}) {
-  const store: Record<string, StateNode> = { ...initial };
+type InitialStateNode = Omit<StateNode, "rev"> & { rev?: number };
+
+function createMemoryState(initial: Record<string, InitialStateNode> = {}) {
+  const store = Object.fromEntries(
+    Object.entries(initial).map(([id, node]) => [
+      id,
+      { ...node, rev: node.rev ?? 1 },
+    ]),
+  ) as Record<string, StateNode>;
 
   return {
     store,
     get: vi.fn(async (id: string) => store[id]),
-    update: vi.fn(async (id: string, patch: Partial<StateNode>) => {
-      store[id] = {
-        ...(store[id] ?? {}),
-        ...patch,
-      } as StateNode;
-    }),
-    delete: vi.fn(async (id: string) => {
+    update: vi.fn(
+      async (id: string, patch: Partial<StateNode>, expectedRev: number) => {
+        const actualRev = store[id]?.rev ?? 0;
+        if (actualRev !== expectedRev) {
+          throw new RevConflict(id, expectedRev, store[id]?.rev);
+        }
+        const rev = actualRev + 1;
+        store[id] = {
+          ...(store[id] ?? {}),
+          ...patch,
+          rev,
+        } as StateNode;
+        return { rev };
+      },
+    ),
+    delete: vi.fn(async (id: string, expectedRev: number) => {
+      const actualRev = store[id]?.rev ?? 0;
+      if (actualRev !== expectedRev) {
+        throw new RevConflict(id, expectedRev, store[id]?.rev);
+      }
       delete store[id];
     }),
     values: vi.fn(async () => Object.values(store)),
+    lease: vi.fn(async (scope: string, ttl: number) => {
+      let expiresAt = new Date(Date.now() + ttl).toISOString();
+      return {
+        scope,
+        get expiresAt() {
+          return expiresAt;
+        },
+        renew: vi.fn(async (nextTtl: number) => {
+          expiresAt = new Date(Date.now() + nextTtl).toISOString();
+          return expiresAt;
+        }),
+        release: vi.fn(async () => undefined),
+      };
+    }),
   };
 }
 
 function createTestResourceClass(opts: {
   type: `${string}/${string}/${string}`;
-  create?: (params: Record<string, unknown>) => Promise<Record<string, unknown> | void>;
+  create?: (
+    params: Record<string, unknown>,
+  ) => Promise<Record<string, unknown> | void>;
   read?: (key: Record<string, unknown>) => Promise<Record<string, unknown>>;
   update?: (
     key: Record<string, unknown>,
@@ -32,7 +73,10 @@ function createTestResourceClass(opts: {
     params: Record<string, unknown>,
     state: Record<string, unknown>,
   ) => Promise<void>;
-  delete?: (key: Record<string, unknown>, state: Record<string, unknown>) => Promise<void>;
+  delete?: (
+    key: Record<string, unknown>,
+    state: Record<string, unknown>,
+  ) => Promise<void>;
 }) {
   return resource({ type: opts.type })
     .defineSchema({
@@ -103,6 +147,61 @@ describe("reconciler deploy", () => {
     expect(updateSpy.mock.calls[0]?.[1]).toEqual({ name: "new" });
     expect(events).toContain("create:success:new");
     expect(events).toContain("update:success:existing");
+  });
+
+  it("persists first-time creates with an expect-absent revision", async () => {
+    const CreateResource = createTestResourceClass({
+      type: "test/service/first-create",
+      create: async () => ({ name: "new" }),
+      read: async () => ({ name: "new" }),
+    });
+    const state = createMemoryState();
+    const reconciler = new Reconciler({ state, driftDetection: false });
+
+    await reconciler.deploy([
+      new CreateResource({ id: "new", config: { name: "new" } }),
+    ]);
+
+    expect(state.update).toHaveBeenCalledWith("new", expect.any(Object), 0);
+  });
+
+  it("leases a resource before remote create so concurrent deploys cannot duplicate it", async () => {
+    let signalCreateStarted!: () => void;
+    const createStarted = new Promise<void>((resolve) => {
+      signalCreateStarted = resolve;
+    });
+    let allowCreateToFinish!: () => void;
+    const createCanFinish = new Promise<void>((resolve) => {
+      allowCreateToFinish = resolve;
+    });
+    const createSpy = vi.fn(async () => {
+      signalCreateStarted();
+      await createCanFinish;
+      return { name: "new" };
+    });
+    const CreateResource = createTestResourceClass({
+      type: "test/service/concurrent-create",
+      create: createSpy,
+      read: async () => ({ name: "new" }),
+    });
+    const state = new MemoryStateBackend();
+    const first = new Reconciler({ state, driftDetection: false });
+    const second = new Reconciler({ state, driftDetection: false });
+
+    const firstDeploy = first.deploy([
+      new CreateResource({ id: "new", config: { name: "new" } }),
+    ]);
+    await createStarted;
+
+    await expect(
+      second.deploy([
+        new CreateResource({ id: "new", config: { name: "new" } }),
+      ]),
+    ).rejects.toBeInstanceOf(LeaseConflict);
+
+    allowCreateToFinish();
+    await firstDeploy;
+    expect(createSpy).toHaveBeenCalledOnce();
   });
 
   it("runs independent resources concurrently per dependency depth", async () => {
@@ -228,7 +327,7 @@ describe("reconciler deploy", () => {
     await reconciler.deploy([]);
 
     expect(deleteSpy).toHaveBeenCalledOnce();
-    expect(state.delete).toHaveBeenCalledWith("orphan");
+    expect(state.delete).toHaveBeenCalledWith("orphan", 1);
   });
 
   it("dryRun emits operation intent without applying side effects", async () => {
@@ -267,7 +366,9 @@ describe("reconciler deploy", () => {
       driftDetection: false,
       emit: async (event) => {
         if ("operation" in event) {
-          operationEvents.push(`${event.operation}:${event.status}:${event.resourceId}`);
+          operationEvents.push(
+            `${event.operation}:${event.status}:${event.resourceId}`,
+          );
         }
       },
     });
@@ -286,6 +387,62 @@ describe("reconciler deploy", () => {
 });
 
 describe("reconciler destroy + refresh", () => {
+  it("re-reads state and retries destroy on RevConflict", async () => {
+    const deleteSpy = vi.fn(async () => undefined);
+    const DestroyResource = createTestResourceClass({
+      type: "test/service/destroy-retry",
+      delete: deleteSpy,
+    });
+    const state = createMemoryState({
+      doomed: {
+        rev: 1,
+        id: "doomed",
+        groupId: -1,
+        groupType: "",
+        type: DestroyResource.type,
+        config: { name: "doomed" },
+        params: { name: "doomed" },
+        output: { name: "doomed" },
+        lastOperation: "create",
+        lastOperationAt: new Date().toISOString(),
+      },
+    });
+    state.delete
+      .mockRejectedValueOnce(new RevConflict("doomed", 1, 2))
+      .mockImplementation(async (id: string) => {
+        delete state.store[id];
+      });
+
+    const reconciler = new Reconciler({ state });
+    await reconciler.destroy([
+      new DestroyResource({ id: "doomed", config: { name: "doomed" } }),
+    ]);
+
+    expect(state.delete).toHaveBeenCalledTimes(2);
+    expect(state.store.doomed).toBeUndefined();
+  });
+
+  it("holds a backend lease for the orphan snapshot", async () => {
+    const state = createMemoryState();
+    const release = vi.fn(async () => undefined);
+    const lease = vi.fn(async () => ({
+      scope: "reconciler:orphan-deletion",
+      expiresAt: new Date(Date.now() + 10_000).toISOString(),
+      renew: vi.fn(async () => new Date(Date.now() + 10_000).toISOString()),
+      release,
+    }));
+    const reconciler = new Reconciler({
+      state: { ...state, lease },
+      mutationLeaseTtl: 10_000,
+    });
+
+    await reconciler.refresh([]);
+
+    expect(lease).toHaveBeenCalledWith("reconciler:orphan-deletion", 10_000);
+    expect(state.values).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("destroys resources in reverse dependency order", async () => {
     const destroyOrder: string[] = [];
     const deleteA = vi.fn(async () => {
@@ -363,9 +520,9 @@ describe("reconciler destroy + refresh", () => {
     await reconciler.destroy([resourceA, resourceB, resourceC]);
 
     expect(destroyOrder).toEqual(["c", "b", "a"]);
-    expect(state.delete).toHaveBeenCalledWith("a");
-    expect(state.delete).toHaveBeenCalledWith("b");
-    expect(state.delete).toHaveBeenCalledWith("c");
+    expect(state.delete).toHaveBeenCalledWith("a", 1);
+    expect(state.delete).toHaveBeenCalledWith("b", 1);
+    expect(state.delete).toHaveBeenCalledWith("c", 1);
   });
 
   it("refresh removes orphan state entries", async () => {
@@ -412,8 +569,8 @@ describe("reconciler destroy + refresh", () => {
     await reconciler.refresh([keep]);
 
     expect(deleteSpy).toHaveBeenCalledOnce();
-    expect(state.delete).toHaveBeenCalledWith("orphan");
-    expect(state.delete).not.toHaveBeenCalledWith("keep");
+    expect(state.delete).toHaveBeenCalledWith("orphan", 1);
+    expect(state.delete).not.toHaveBeenCalledWith("keep", expect.anything());
   });
 
   it("destroy and refresh dryRun emit operation events without side effects", async () => {
@@ -464,7 +621,9 @@ describe("reconciler destroy + refresh", () => {
       registry: createResourceRegistry([OrphanResource]),
       emit: async (event) => {
         if ("operation" in event) {
-          operationEvents.push(`${event.operation}:${event.status}:${event.resourceId}`);
+          operationEvents.push(
+            `${event.operation}:${event.status}:${event.resourceId}`,
+          );
         }
       },
     });

--- a/packages/reconciler/test/reconciler.deploy.test.ts
+++ b/packages/reconciler/test/reconciler.deploy.test.ts
@@ -8,21 +8,14 @@ import {
 } from "@notation/state";
 import { Reconciler, createResourceRegistry } from "../src";
 
-type InitialStateNode = Omit<StateNode, "rev"> & { rev?: number };
-
-function createMemoryState(initial: Record<string, InitialStateNode> = {}) {
-  const store = Object.fromEntries(
-    Object.entries(initial).map(([id, node]) => [
-      id,
-      { ...node, rev: node.rev ?? 1 },
-    ]),
-  ) as Record<string, StateNode>;
+function createMemoryState(initial: Record<string, StateNode> = {}) {
+  const store: Record<string, StateNode> = { ...initial };
 
   return {
     store,
     get: vi.fn(async (id: string) => store[id]),
     update: vi.fn(
-      async (id: string, patch: Partial<StateNode>, expectedRev: number) => {
+      async (id: string, expectedRev: number, patch: Partial<StateNode>) => {
         const actualRev = store[id]?.rev ?? 0;
         if (actualRev !== expectedRev) {
           throw new RevConflict(id, expectedRev, store[id]?.rev);
@@ -114,6 +107,7 @@ describe("reconciler deploy", () => {
 
     const state = createMemoryState({
       existing: {
+        rev: 1,
         id: "existing",
         groupId: -1,
         groupType: "",
@@ -162,7 +156,7 @@ describe("reconciler deploy", () => {
       new CreateResource({ id: "new", config: { name: "new" } }),
     ]);
 
-    expect(state.update).toHaveBeenCalledWith("new", expect.any(Object), 0);
+    expect(state.update).toHaveBeenCalledWith("new", 0, expect.any(Object));
   });
 
   it("leases a resource before remote create so concurrent deploys cannot duplicate it", async () => {
@@ -263,6 +257,7 @@ describe("reconciler deploy", () => {
 
     const state = createMemoryState({
       resource: {
+        rev: 1,
         id: "resource",
         groupId: -1,
         groupType: "",
@@ -306,6 +301,7 @@ describe("reconciler deploy", () => {
 
     const state = createMemoryState({
       orphan: {
+        rev: 1,
         id: "orphan",
         groupId: -1,
         groupType: "",
@@ -346,6 +342,7 @@ describe("reconciler deploy", () => {
 
     const state = createMemoryState({
       orphan: {
+        rev: 1,
         id: "orphan",
         groupId: -1,
         groupType: "",
@@ -482,6 +479,7 @@ describe("reconciler destroy + refresh", () => {
 
     const state = createMemoryState({
       a: {
+        rev: 1,
         id: "a",
         groupId: -1,
         groupType: "",
@@ -493,6 +491,7 @@ describe("reconciler destroy + refresh", () => {
         lastOperationAt: new Date().toISOString(),
       },
       b: {
+        rev: 1,
         id: "b",
         groupId: -1,
         groupType: "",
@@ -504,6 +503,7 @@ describe("reconciler destroy + refresh", () => {
         lastOperationAt: new Date().toISOString(),
       },
       c: {
+        rev: 1,
         id: "c",
         groupId: -1,
         groupType: "",
@@ -538,6 +538,7 @@ describe("reconciler destroy + refresh", () => {
     const keep = new KeepResource({ id: "keep", config: { name: "keep" } });
     const state = createMemoryState({
       keep: {
+        rev: 1,
         id: "keep",
         groupId: -1,
         groupType: "",
@@ -549,6 +550,7 @@ describe("reconciler destroy + refresh", () => {
         lastOperationAt: new Date().toISOString(),
       },
       orphan: {
+        rev: 1,
         id: "orphan",
         groupId: -1,
         groupType: "",
@@ -591,6 +593,7 @@ describe("reconciler destroy + refresh", () => {
 
     const state = createMemoryState({
       "destroy-me": {
+        rev: 1,
         id: "destroy-me",
         groupId: -1,
         groupType: "",
@@ -602,6 +605,7 @@ describe("reconciler destroy + refresh", () => {
         lastOperationAt: new Date().toISOString(),
       },
       orphan: {
+        rev: 1,
         id: "orphan",
         groupId: -1,
         groupType: "",

--- a/packages/reconciler/test/reconciler.deploy.test.ts
+++ b/packages/reconciler/test/reconciler.deploy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { resource } from "@notation/resource";
+import { resource, type ErrorMatcher } from "@notation/resource";
 import {
   LeaseConflict,
   MemoryStateBackend,
@@ -70,6 +70,7 @@ function createTestResourceClass(opts: {
     key: Record<string, unknown>,
     state: Record<string, unknown>,
   ) => Promise<void>;
+  notFoundOnError?: ErrorMatcher[];
 }) {
   return resource({ type: opts.type })
     .defineSchema({
@@ -84,6 +85,7 @@ function createTestResourceClass(opts: {
       read: opts.read,
       update: opts.update,
       delete: opts.delete ?? (async () => undefined),
+      notFoundOnError: opts.notFoundOnError,
     });
 }
 
@@ -196,6 +198,155 @@ describe("reconciler deploy", () => {
     allowCreateToFinish();
     await firstDeploy;
     expect(createSpy).toHaveBeenCalledOnce();
+  });
+
+  it("reads remote state after an update conflict instead of repeating the update", async () => {
+    let remoteName = "old";
+    const readSpy = vi.fn(async () => ({ name: remoteName }));
+    const updateSpy = vi.fn(async (_key, _patch, params) => {
+      remoteName = params.name as string;
+    });
+    const UpdateResource = createTestResourceClass({
+      type: "test/service/update-conflict",
+      read: readSpy,
+      update: updateSpy,
+    });
+    const state = createMemoryState({
+      existing: {
+        rev: 1,
+        id: "existing",
+        groupId: -1,
+        groupType: "",
+        type: UpdateResource.type,
+        config: { name: "old" },
+        params: { name: "old" },
+        output: { name: "old" },
+        lastOperation: "create",
+        lastOperationAt: new Date().toISOString(),
+      },
+    });
+    const updateState = state.update.getMockImplementation()!;
+    state.update
+      .mockImplementationOnce(async () => {
+        state.store.existing = {
+          ...state.store.existing!,
+          rev: 2,
+          config: { name: "concurrent" },
+          params: { name: "concurrent" },
+          output: { name: "concurrent" },
+        };
+        throw new RevConflict("existing", 1, 2);
+      })
+      .mockImplementation(updateState);
+
+    const reconciler = new Reconciler({ state, driftDetection: false });
+    await reconciler.deploy([
+      new UpdateResource({ id: "existing", config: { name: "new" } }),
+    ]);
+
+    expect(updateSpy).toHaveBeenCalledOnce();
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    expect(state.update).toHaveBeenLastCalledWith(
+      "existing",
+      2,
+      expect.objectContaining({
+        params: { name: "new" },
+        output: { name: "new" },
+        lastOperation: "drift",
+      }),
+    );
+    expect(state.store.existing).toMatchObject({
+      rev: 3,
+      params: { name: "new" },
+      output: { name: "new" },
+    });
+  });
+
+  it("reads remote state after a create conflict instead of creating twice", async () => {
+    let remoteName: string | undefined;
+    const createSpy = vi.fn(async (params) => {
+      remoteName = params.name as string;
+      return { name: remoteName };
+    });
+    const readSpy = vi.fn(async () => ({ name: remoteName! }));
+    const CreateResource = createTestResourceClass({
+      type: "test/service/create-conflict",
+      create: createSpy,
+      read: readSpy,
+    });
+    const state = createMemoryState();
+    const updateState = state.update.getMockImplementation()!;
+    state.update
+      .mockImplementationOnce(async () => {
+        state.store.new = {
+          rev: 1,
+          id: "new",
+          groupId: -1,
+          groupType: "",
+          type: CreateResource.type,
+          config: { name: "concurrent" },
+          params: { name: "concurrent" },
+          output: { name: "concurrent" },
+          lastOperation: "create",
+          lastOperationAt: new Date().toISOString(),
+        };
+        throw new RevConflict("new", 0, 1);
+      })
+      .mockImplementation(updateState);
+
+    const reconciler = new Reconciler({ state, driftDetection: false });
+    await reconciler.deploy([
+      new CreateResource({ id: "new", config: { name: "new" } }),
+    ]);
+
+    expect(createSpy).toHaveBeenCalledOnce();
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    expect(state.store.new).toMatchObject({
+      rev: 2,
+      params: { name: "new" },
+      output: { name: "new" },
+      lastOperation: "drift",
+    });
+  });
+
+  it("does not blindly retry a conflicted mutation without a read operation", async () => {
+    const updateSpy = vi.fn(async () => undefined);
+    const UpdateResource = createTestResourceClass({
+      type: "test/service/unreadable-conflict",
+      update: updateSpy,
+    });
+    const state = createMemoryState({
+      existing: {
+        rev: 1,
+        id: "existing",
+        groupId: -1,
+        groupType: "",
+        type: UpdateResource.type,
+        config: { name: "old" },
+        params: { name: "old" },
+        output: { name: "old" },
+        lastOperation: "create",
+        lastOperationAt: new Date().toISOString(),
+      },
+    });
+    state.update.mockImplementationOnce(async () => {
+      state.store.existing = { ...state.store.existing!, rev: 2 };
+      throw new RevConflict("existing", 1, 2);
+    });
+
+    const reconciler = new Reconciler({ state, driftDetection: false });
+    await expect(
+      reconciler.deploy([
+        new UpdateResource({ id: "existing", config: { name: "new" } }),
+      ]),
+    ).rejects.toMatchObject({
+      id: "existing",
+      expectedRev: 1,
+      actualRev: 2,
+    });
+
+    expect(updateSpy).toHaveBeenCalledOnce();
+    expect(state.update).toHaveBeenCalledOnce();
   });
 
   it("runs independent resources concurrently per dependency depth", async () => {
@@ -384,11 +535,24 @@ describe("reconciler deploy", () => {
 });
 
 describe("reconciler destroy + refresh", () => {
-  it("re-reads state and retries destroy on RevConflict", async () => {
-    const deleteSpy = vi.fn(async () => undefined);
+  it("reads remote state after a delete conflict instead of deleting twice", async () => {
+    let remoteExists = true;
+    const deleteSpy = vi.fn(async () => {
+      remoteExists = false;
+    });
+    const readSpy = vi.fn(async () => {
+      if (!remoteExists) {
+        const error = new Error("gone");
+        error.name = "RemoteMissing";
+        throw error;
+      }
+      return { name: "doomed" };
+    });
     const DestroyResource = createTestResourceClass({
       type: "test/service/destroy-retry",
+      read: readSpy,
       delete: deleteSpy,
+      notFoundOnError: [{ name: "RemoteMissing", reason: "deleted" }],
     });
     const state = createMemoryState({
       doomed: {
@@ -404,17 +568,21 @@ describe("reconciler destroy + refresh", () => {
         lastOperationAt: new Date().toISOString(),
       },
     });
+    const deleteState = state.delete.getMockImplementation()!;
     state.delete
-      .mockRejectedValueOnce(new RevConflict("doomed", 1, 2))
-      .mockImplementation(async (id: string) => {
-        delete state.store[id];
-      });
+      .mockImplementationOnce(async () => {
+        state.store.doomed = { ...state.store.doomed!, rev: 2 };
+        throw new RevConflict("doomed", 1, 2);
+      })
+      .mockImplementation(deleteState);
 
     const reconciler = new Reconciler({ state });
     await reconciler.destroy([
       new DestroyResource({ id: "doomed", config: { name: "doomed" } }),
     ]);
 
+    expect(deleteSpy).toHaveBeenCalledOnce();
+    expect(readSpy).toHaveBeenCalledOnce();
     expect(state.delete).toHaveBeenCalledTimes(2);
     expect(state.store.doomed).toBeUndefined();
   });

--- a/packages/reconciler/test/reconciler.plan.test.ts
+++ b/packages/reconciler/test/reconciler.plan.test.ts
@@ -9,12 +9,14 @@ function createMemoryState(initial: Record<string, StateNode> = {}) {
   return {
     store,
     get: vi.fn(async (id: string) => store[id]),
-    update: vi.fn(async (id: string, patch: Partial<StateNode>) => {
-      store[id] = {
-        ...(store[id] ?? {}),
-        ...patch,
-      } as StateNode;
-    }),
+    update: vi.fn(
+      async (id: string, expectedRev: number, patch: Partial<StateNode>) => {
+        store[id] = {
+          ...(store[id] ?? {}),
+          ...patch,
+        } as StateNode;
+      },
+    ),
     delete: vi.fn(async (id: string) => {
       delete store[id];
     }),

--- a/packages/state-sqlite/package.json
+++ b/packages/state-sqlite/package.json
@@ -1,0 +1,20 @@
+{
+  "type": "module",
+  "name": "@notation/state-sqlite",
+  "version": "0.1.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup --clean",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@notation/state": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.4"
+  }
+}

--- a/packages/state-sqlite/src/index.ts
+++ b/packages/state-sqlite/src/index.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
   LeaseConflict,
@@ -12,6 +14,7 @@ export class SqliteStateBackend implements StateBackend {
   readonly #database: DatabaseSync;
 
   constructor(path: string) {
+    mkdirSync(dirname(path), { recursive: true });
     this.#database = new DatabaseSync(path);
     this.#database.exec("PRAGMA busy_timeout = 5000");
     this.#database.exec(`
@@ -51,8 +54,8 @@ export class SqliteStateBackend implements StateBackend {
 
   async update(
     id: string,
-    patch: Partial<StateNode>,
     expectedRev: number,
+    patch: Partial<StateNode>,
   ): Promise<{ rev: number }> {
     this.#database.exec("BEGIN IMMEDIATE");
     try {

--- a/packages/state-sqlite/src/index.ts
+++ b/packages/state-sqlite/src/index.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import {
+  LeaseConflict,
+  RevConflict,
+  type Lease,
+  type StateBackend,
+  type StateNode,
+} from "@notation/state";
+
+export class SqliteStateBackend implements StateBackend {
+  readonly #database: DatabaseSync;
+
+  constructor(path: string) {
+    this.#database = new DatabaseSync(path);
+    this.#database.exec("PRAGMA busy_timeout = 5000");
+    this.#database.exec(`
+      CREATE TABLE IF NOT EXISTS resources (
+        id TEXT PRIMARY KEY,
+        rev INTEGER NOT NULL,
+        value TEXT NOT NULL
+      )
+    `);
+    this.#database.exec(`
+      CREATE TABLE IF NOT EXISTS resource_leases (
+        scope TEXT PRIMARY KEY,
+        owner TEXT NOT NULL,
+        expires_at INTEGER NOT NULL
+      )
+    `);
+  }
+
+  close(): void {
+    this.#database.close();
+  }
+
+  async get(id: string): Promise<StateNode | undefined> {
+    const row = this.#database
+      .prepare("SELECT value FROM resources WHERE id = ?")
+      .get(id) as { value: string } | undefined;
+    return row ? (JSON.parse(row.value) as StateNode) : undefined;
+  }
+
+  async has(id: string): Promise<boolean> {
+    return Boolean(
+      this.#database
+        .prepare("SELECT 1 FROM resources WHERE id = ?")
+        .get(id),
+    );
+  }
+
+  async update(
+    id: string,
+    patch: Partial<StateNode>,
+    expectedRev: number,
+  ): Promise<{ rev: number }> {
+    this.#database.exec("BEGIN IMMEDIATE");
+    try {
+      const current = await this.get(id);
+      // A missing record counts as rev 0, so expectedRev: 0 = "must not exist".
+      if ((current?.rev ?? 0) !== expectedRev) {
+        throw new RevConflict(id, expectedRev, current?.rev);
+      }
+
+      const rev = (current?.rev ?? 0) + 1;
+      const node = { ...current, ...patch, rev } as StateNode;
+      if (current) {
+        const result = this.#database
+          .prepare(
+            "UPDATE resources SET rev = ?, value = ? WHERE id = ? AND rev = ?",
+          )
+          .run(rev, JSON.stringify(node), id, current.rev);
+        if (result.changes !== 1) {
+          const actual = await this.get(id);
+          throw new RevConflict(id, current.rev, actual?.rev);
+        }
+      } else {
+        this.#database
+          .prepare(
+            "INSERT INTO resources (id, rev, value) VALUES (?, ?, ?)",
+          )
+          .run(id, rev, JSON.stringify(node));
+      }
+      this.#database.exec("COMMIT");
+      return { rev };
+    } catch (error) {
+      this.#database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  async delete(id: string, expectedRev: number): Promise<void> {
+    const current = await this.get(id);
+    if ((current?.rev ?? 0) !== expectedRev) {
+      throw new RevConflict(id, expectedRev, current?.rev);
+    }
+    if (!current) return;
+
+    const result = this.#database
+      .prepare("DELETE FROM resources WHERE id = ? AND rev = ?")
+      .run(id, current.rev);
+    if (result.changes !== 1) {
+      const actual = await this.get(id);
+      throw new RevConflict(id, current.rev, actual?.rev);
+    }
+  }
+
+  async values(): Promise<StateNode[]> {
+    const rows = this.#database
+      .prepare("SELECT value FROM resources ORDER BY id")
+      .all() as { value: string }[];
+    return rows.map(({ value }) => JSON.parse(value) as StateNode);
+  }
+
+  async lease(scope: string, ttl: number): Promise<Lease> {
+    if (!Number.isFinite(ttl) || ttl <= 0) {
+      throw new RangeError(
+        "Lease TTL must be a positive number of milliseconds",
+      );
+    }
+
+    const owner = randomUUID();
+    const expiresAtMs = Date.now() + ttl;
+    this.#database.exec("BEGIN IMMEDIATE");
+    try {
+      this.#database
+        .prepare(
+          "DELETE FROM resource_leases WHERE scope = ? AND expires_at <= ?",
+        )
+        .run(scope, Date.now());
+      const current = this.#database
+        .prepare("SELECT expires_at FROM resource_leases WHERE scope = ?")
+        .get(scope) as { expires_at: number } | undefined;
+      if (current) {
+        throw new LeaseConflict(
+          scope,
+          new Date(current.expires_at).toISOString(),
+        );
+      }
+      this.#database
+        .prepare(
+          "INSERT INTO resource_leases (scope, owner, expires_at) VALUES (?, ?, ?)",
+        )
+        .run(scope, owner, expiresAtMs);
+      this.#database.exec("COMMIT");
+    } catch (error) {
+      this.#database.exec("ROLLBACK");
+      throw error;
+    }
+
+    let released = false;
+    let currentExpiresAtMs = expiresAtMs;
+    return {
+      scope,
+      get expiresAt() {
+        return new Date(currentExpiresAtMs).toISOString();
+      },
+      renew: async (nextTtl) => {
+        if (!Number.isFinite(nextTtl) || nextTtl <= 0) {
+          throw new RangeError(
+            "Lease TTL must be a positive number of milliseconds",
+          );
+        }
+        const now = Date.now();
+        const nextExpiresAtMs = now + nextTtl;
+        const result = this.#database
+          .prepare(
+            "UPDATE resource_leases SET expires_at = ? WHERE scope = ? AND owner = ? AND expires_at > ?",
+          )
+          .run(nextExpiresAtMs, scope, owner, now);
+        if (result.changes !== 1) {
+          const current = this.#database
+            .prepare("SELECT expires_at FROM resource_leases WHERE scope = ?")
+            .get(scope) as { expires_at: number } | undefined;
+          throw new LeaseConflict(
+            scope,
+            new Date(current?.expires_at ?? 0).toISOString(),
+          );
+        }
+        currentExpiresAtMs = nextExpiresAtMs;
+        return new Date(nextExpiresAtMs).toISOString();
+      },
+      release: async () => {
+        if (released) return;
+        this.#database
+          .prepare("DELETE FROM resource_leases WHERE scope = ? AND owner = ?")
+          .run(scope, owner);
+        released = true;
+      },
+    };
+  }
+}

--- a/packages/state-sqlite/src/node-sqlite.d.ts
+++ b/packages/state-sqlite/src/node-sqlite.d.ts
@@ -1,0 +1,20 @@
+declare module "node:sqlite" {
+  export type StatementResult = { changes: number | bigint };
+  export class StatementSync {
+    get(...values: unknown[]): unknown;
+    all(...values: unknown[]): unknown[];
+    run(...values: unknown[]): StatementResult;
+  }
+  export class DatabaseSync {
+    constructor(path: string);
+    exec(sql: string): void;
+    prepare(sql: string): StatementSync;
+    close(): void;
+  }
+}
+
+// The shared tsconfig does not load @types/node, so declare the one export
+// this package uses.
+declare module "node:crypto" {
+  export function randomUUID(): string;
+}

--- a/packages/state-sqlite/test/state-sqlite.test.ts
+++ b/packages/state-sqlite/test/state-sqlite.test.ts
@@ -25,22 +25,18 @@ describe("SqliteStateBackend", () => {
   it("persists revisions and enforces compare-and-swap", async () => {
     const backend = await createBackend();
     await expect(
-      backend.update(
-        "service",
-        {
-          id: "service",
-          type: "test/service/main",
-          config: {},
-          params: {},
-          output: {},
-          lastOperation: "create",
-          lastOperationAt: "2026-07-15T00:00:00.000Z",
-        },
-        0,
-      ),
+      backend.update("service", 0, {
+        id: "service",
+        type: "test/service/main",
+        config: {},
+        params: {},
+        output: {},
+        lastOperation: "create",
+        lastOperationAt: "2026-07-15T00:00:00.000Z",
+      }),
     ).resolves.toEqual({ rev: 1 });
     await expect(
-      backend.update("service", { output: { ready: true } }, 1),
+      backend.update("service", 1, { output: { ready: true } }),
     ).resolves.toEqual({
       rev: 2,
     });
@@ -111,19 +107,15 @@ describe("SqliteStateBackend", () => {
     await once(blocker.stdout!, "data");
 
     await expect(
-      backend.update(
-        "service",
-        {
-          id: "service",
-          type: "test/service/main",
-          config: {},
-          params: {},
-          output: {},
-          lastOperation: "create",
-          lastOperationAt: "2026-07-15T00:00:00.000Z",
-        },
-        0,
-      ),
+      backend.update("service", 0, {
+        id: "service",
+        type: "test/service/main",
+        config: {},
+        params: {},
+        output: {},
+        lastOperation: "create",
+        lastOperationAt: "2026-07-15T00:00:00.000Z",
+      }),
     ).resolves.toEqual({ rev: 1 });
     await blockerExited;
   });

--- a/packages/state-sqlite/test/state-sqlite.test.ts
+++ b/packages/state-sqlite/test/state-sqlite.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SqliteStateBackend } from "../src";
+
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () =>
+  Promise.all(cleanups.splice(0).map((cleanup) => cleanup())),
+);
+
+async function createBackend() {
+  const directory = await mkdtemp(path.join(tmpdir(), "notation-sqlite-"));
+  const backend = new SqliteStateBackend(path.join(directory, "state.db"));
+  cleanups.push(async () => {
+    backend.close();
+    await rm(directory, { recursive: true, force: true });
+  });
+  return backend;
+}
+
+describe("SqliteStateBackend", () => {
+  it("persists revisions and enforces compare-and-swap", async () => {
+    const backend = await createBackend();
+    await expect(
+      backend.update(
+        "service",
+        {
+          id: "service",
+          type: "test/service/main",
+          config: {},
+          params: {},
+          output: {},
+          lastOperation: "create",
+          lastOperationAt: "2026-07-15T00:00:00.000Z",
+        },
+        0,
+      ),
+    ).resolves.toEqual({ rev: 1 });
+    await expect(
+      backend.update("service", { output: { ready: true } }, 1),
+    ).resolves.toEqual({
+      rev: 2,
+    });
+    await expect(backend.delete("service", 1)).rejects.toMatchObject({
+      name: "RevConflict",
+      actualRev: 2,
+    });
+  });
+
+  it("coordinates leases across backend instances and releases by owner", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "notation-sqlite-lease-"),
+    );
+    const databasePath = path.join(directory, "state.db");
+    const first = new SqliteStateBackend(databasePath);
+    const second = new SqliteStateBackend(databasePath);
+    cleanups.push(async () => {
+      first.close();
+      second.close();
+      await rm(directory, { recursive: true, force: true });
+    });
+
+    const lease = await first.lease("orphans", 10_000);
+    await expect(second.lease("orphans", 10_000)).rejects.toMatchObject({
+      name: "LeaseConflict",
+      scope: "orphans",
+    });
+    const firstExpiry = lease.expiresAt;
+    await lease.renew(20_000);
+    expect(lease.expiresAt).not.toBe(firstExpiry);
+    await lease.release();
+    const nextLease = await second.lease("orphans", 10_000);
+    expect(nextLease).toMatchObject({ scope: "orphans" });
+    await nextLease.release();
+  });
+
+  it("waits for a concurrent writer instead of raising database locked", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "notation-sqlite-busy-"),
+    );
+    const databasePath = path.join(directory, "state.db");
+    const backend = new SqliteStateBackend(databasePath);
+    cleanups.push(async () => {
+      backend.close();
+      await rm(directory, { recursive: true, force: true });
+    });
+
+    const blocker = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        `
+          import { DatabaseSync } from "node:sqlite";
+          const database = new DatabaseSync(process.argv[1]);
+          database.exec("BEGIN IMMEDIATE");
+          process.stdout.write("locked\\n");
+          setTimeout(() => {
+            database.exec("ROLLBACK");
+            database.close();
+          }, 100);
+        `,
+        databasePath,
+      ],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+    const blockerExited = once(blocker, "exit");
+    await once(blocker.stdout!, "data");
+
+    await expect(
+      backend.update(
+        "service",
+        {
+          id: "service",
+          type: "test/service/main",
+          config: {},
+          params: {},
+          output: {},
+          lastOperation: "create",
+          lastOperationAt: "2026-07-15T00:00:00.000Z",
+        },
+        0,
+      ),
+    ).resolves.toEqual({ rev: 1 });
+    await blockerExited;
+  });
+});

--- a/packages/state-sqlite/tsconfig.json
+++ b/packages/state-sqlite/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": ["src", "test"]
+}

--- a/packages/state-sqlite/tsconfig.json
+++ b/packages/state-sqlite/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": ["src", "test"]
 }

--- a/packages/state-sqlite/tsup.config.ts
+++ b/packages/state-sqlite/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  // node:sqlite only resolves with the node: prefix; don't let tsup strip it.
+  removeNodeProtocol: false,
+});

--- a/packages/state/src/conflicts.ts
+++ b/packages/state/src/conflicts.ts
@@ -1,0 +1,24 @@
+export class RevConflict extends Error {
+  readonly name = "RevConflict";
+
+  constructor(
+    readonly id: string,
+    readonly expectedRev: number,
+    readonly actualRev: number | undefined,
+  ) {
+    super(
+      `State revision conflict for ${id}: expected ${expectedRev}, got ${actualRev ?? "missing"}`,
+    );
+  }
+}
+
+export class LeaseConflict extends Error {
+  readonly name = "LeaseConflict";
+
+  constructor(
+    readonly scope: string,
+    readonly expiresAt: string,
+  ) {
+    super(`State lease conflict for ${scope}: held until ${expiresAt}`);
+  }
+}

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./state";
+export * from "./conflicts";

--- a/packages/state/src/state.ts
+++ b/packages/state/src/state.ts
@@ -1,7 +1,18 @@
-import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { LeaseConflict, RevConflict } from "./conflicts";
 
 export type StateNode = {
+  rev: number;
   id: string;
   type: string;
   config: Record<string, unknown>;
@@ -15,15 +26,32 @@ export type StateNode = {
 export interface StateBackend {
   get(id: string): Promise<StateNode | undefined>;
   has(id: string): Promise<boolean>;
-  update(id: string, patch: Partial<StateNode>): Promise<void>;
-  delete(id: string): Promise<void>;
+  /**
+   * The stored revision must match expectedRev. A missing record counts as
+   * revision 0, so expectedRev: 0 asserts that the record does not exist yet.
+   */
+  update(
+    id: string,
+    patch: Partial<StateNode>,
+    expectedRev: number,
+  ): Promise<{ rev: number }>;
+  delete(id: string, expectedRev: number): Promise<void>;
   values(): Promise<StateNode[]>;
-};
+  lease(scope: string, ttl: number): Promise<Lease>;
+}
+
+export interface Lease {
+  readonly scope: string;
+  readonly expiresAt: string;
+  renew(ttl: number): Promise<string>;
+  release(): Promise<void>;
+}
 
 export type State = StateBackend;
 
 export class MemoryStateBackend implements StateBackend {
   #state: Record<string, StateNode>;
+  #leases = new Map<string, { owner: string; expiresAtMs: number }>();
 
   constructor(initialState: Record<string, StateNode> = {}) {
     this.#state = cloneAsPersistedState(initialState);
@@ -39,17 +67,26 @@ export class MemoryStateBackend implements StateBackend {
     return id in state;
   }
 
-  async update(id: string, patch: Partial<StateNode>): Promise<void> {
+  async update(
+    id: string,
+    patch: Partial<StateNode>,
+    expectedRev: number,
+  ): Promise<{ rev: number }> {
     const state = await this.readState();
+    assertExpectedRev(id, state[id], expectedRev);
+    const rev = (state[id]?.rev ?? 0) + 1;
     state[id] = {
       ...state[id],
       ...patch,
+      rev,
     } as StateNode;
     await this.writeState(state);
+    return { rev };
   }
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string, expectedRev: number): Promise<void> {
     const state = await this.readState();
+    assertExpectedRev(id, state[id], expectedRev);
     delete state[id];
     await this.writeState(state);
   }
@@ -71,6 +108,46 @@ export class MemoryStateBackend implements StateBackend {
       .map(([, value]) => value);
   }
 
+  async lease(scope: string, ttl: number): Promise<Lease> {
+    assertLeaseTtl(ttl);
+    const now = Date.now();
+    const current = this.#leases.get(scope);
+    if (current && current.expiresAtMs > now) {
+      throw new LeaseConflict(
+        scope,
+        new Date(current.expiresAtMs).toISOString(),
+      );
+    }
+
+    const owner = randomUUID();
+    let expiresAtMs = now + ttl;
+    this.#leases.set(scope, { owner, expiresAtMs });
+
+    return {
+      scope,
+      get expiresAt() {
+        return new Date(expiresAtMs).toISOString();
+      },
+      renew: async (nextTtl) => {
+        assertLeaseTtl(nextTtl);
+        const held = this.#leases.get(scope);
+        if (!held || held.owner !== owner || held.expiresAtMs <= Date.now()) {
+          throw new LeaseConflict(
+            scope,
+            new Date(held?.expiresAtMs ?? 0).toISOString(),
+          );
+        }
+        expiresAtMs = Date.now() + nextTtl;
+        held.expiresAtMs = expiresAtMs;
+        return new Date(expiresAtMs).toISOString();
+      },
+      release: async () => {
+        if (this.#leases.get(scope)?.owner === owner)
+          this.#leases.delete(scope);
+      },
+    };
+  }
+
   private async readState(): Promise<Record<string, StateNode>> {
     return cloneAsPersistedState(this.#state);
   }
@@ -79,6 +156,10 @@ export class MemoryStateBackend implements StateBackend {
     this.#state = cloneAsPersistedState(state);
   }
 }
+
+const FILE_LOCK_STALE_MS = 10_000;
+const FILE_LOCK_TIMEOUT_MS = 5_000;
+const FILE_LOCK_RETRY_MS = 25;
 
 export class FileStateBackend implements StateBackend {
   constructor(private readonly stateFilePath: string) {}
@@ -93,24 +174,96 @@ export class FileStateBackend implements StateBackend {
     return id in state;
   }
 
-  async update(id: string, patch: Partial<StateNode>): Promise<void> {
-    const state = await this.readState();
-    state[id] = {
-      ...state[id],
-      ...patch,
-    } as StateNode;
-    await this.writeState(state);
+  async update(
+    id: string,
+    patch: Partial<StateNode>,
+    expectedRev: number,
+  ): Promise<{ rev: number }> {
+    return this.withLock(async () => {
+      const state = await this.readState();
+      assertExpectedRev(id, state[id], expectedRev);
+      const rev = (state[id]?.rev ?? 0) + 1;
+      state[id] = {
+        ...state[id],
+        ...patch,
+        rev,
+      } as StateNode;
+      await this.writeState(state);
+      return { rev };
+    });
   }
 
-  async delete(id: string): Promise<void> {
-    const state = await this.readState();
-    delete state[id];
-    await this.writeState(state);
+  async delete(id: string, expectedRev: number): Promise<void> {
+    await this.withLock(async () => {
+      const state = await this.readState();
+      assertExpectedRev(id, state[id], expectedRev);
+      delete state[id];
+      await this.writeState(state);
+    });
   }
 
   async values(): Promise<StateNode[]> {
     const state = await this.readState();
     return Object.values(state);
+  }
+
+  async lease(scope: string, ttl: number): Promise<Lease> {
+    assertLeaseTtl(ttl);
+    const leaseFilePath = `${this.stateFilePath}.${encodeURIComponent(scope)}.lease`;
+    const owner = randomUUID();
+    let expiresAtMs: number;
+    await mkdir(path.dirname(this.stateFilePath), { recursive: true });
+
+    for (;;) {
+      expiresAtMs = Date.now() + ttl;
+      try {
+        await writeFile(leaseFilePath, JSON.stringify({ owner, expiresAtMs }), {
+          flag: "wx",
+        });
+        break;
+      } catch (error) {
+        if (!isFileExistsError(error)) throw error;
+        const current = await readFileLease(leaseFilePath);
+        if (!current || current.expiresAtMs <= Date.now()) {
+          await unlink(leaseFilePath).catch(() => undefined);
+          continue;
+        }
+        throw new LeaseConflict(
+          scope,
+          new Date(current.expiresAtMs).toISOString(),
+        );
+      }
+    }
+
+    return {
+      scope,
+      get expiresAt() {
+        return new Date(expiresAtMs).toISOString();
+      },
+      renew: async (nextTtl) => {
+        assertLeaseTtl(nextTtl);
+        const current = await readFileLease(leaseFilePath);
+        if (
+          !current ||
+          current.owner !== owner ||
+          current.expiresAtMs <= Date.now()
+        ) {
+          throw new LeaseConflict(
+            scope,
+            new Date(current?.expiresAtMs ?? 0).toISOString(),
+          );
+        }
+        expiresAtMs = Date.now() + nextTtl;
+        await writeFile(leaseFilePath, JSON.stringify({ owner, expiresAtMs }));
+        return new Date(expiresAtMs).toISOString();
+      },
+      release: async () => {
+        const current = await readFileLease(leaseFilePath);
+        if (current?.owner === owner) {
+          await unlink(leaseFilePath).catch(() => undefined);
+        }
+      },
+    };
   }
 
   private async readState(): Promise<Record<string, StateNode>> {
@@ -126,13 +279,54 @@ export class FileStateBackend implements StateBackend {
     }
   }
 
+  /**
+   * The read-check-write in update/delete is only safe if no other process
+   * interleaves, so writers hold an exclusive lock file. A lock older than
+   * FILE_LOCK_STALE_MS is treated as abandoned by a crashed process.
+   */
+  private async withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const lockFilePath = `${this.stateFilePath}.lock`;
+    await mkdir(path.dirname(this.stateFilePath), { recursive: true });
+
+    const deadline = Date.now() + FILE_LOCK_TIMEOUT_MS;
+    for (;;) {
+      try {
+        await writeFile(
+          lockFilePath,
+          JSON.stringify({ pid: process.pid, acquiredAt: Date.now() }),
+          { flag: "wx" },
+        );
+        break;
+      } catch (error) {
+        if (!isFileExistsError(error)) throw error;
+        const lockStat = await stat(lockFilePath).catch(() => undefined);
+        if (lockStat && Date.now() - lockStat.mtimeMs > FILE_LOCK_STALE_MS) {
+          await unlink(lockFilePath).catch(() => undefined);
+          continue;
+        }
+        if (Date.now() > deadline) {
+          throw new Error(
+            `Timed out acquiring state lock at ${lockFilePath}; delete it if no other deploy is running`,
+          );
+        }
+        await sleep(FILE_LOCK_RETRY_MS);
+      }
+    }
+
+    try {
+      return await fn();
+    } finally {
+      await unlink(lockFilePath).catch(() => undefined);
+    }
+  }
+
   private async writeState(state: Record<string, StateNode>): Promise<void> {
     const directory = path.dirname(this.stateFilePath);
     await mkdir(directory, { recursive: true });
 
     const tempFilePath = path.join(
       directory,
-      `${path.basename(this.stateFilePath)}.${process.pid}.${Date.now()}.tmp`,
+      `${path.basename(this.stateFilePath)}.${randomUUID()}.tmp`,
     );
 
     const serialized = `${JSON.stringify(state, null, 2)}\n`;
@@ -148,12 +342,51 @@ export class FileStateBackend implements StateBackend {
   }
 }
 
+// A missing record counts as rev 0, so expectedRev: 0 means "must not exist".
+function assertExpectedRev(
+  id: string,
+  node: StateNode | undefined,
+  expectedRev: number,
+): void {
+  if ((node?.rev ?? 0) !== expectedRev) {
+    throw new RevConflict(id, expectedRev, node?.rev);
+  }
+}
+
+function assertLeaseTtl(ttl: number): void {
+  if (!Number.isFinite(ttl) || ttl <= 0) {
+    throw new RangeError("Lease TTL must be a positive number of milliseconds");
+  }
+}
+
+type FileLeaseRecord = { owner: string; expiresAtMs: number };
+
+async function readFileLease(
+  filePath: string,
+): Promise<FileLeaseRecord | undefined> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as FileLeaseRecord;
+  } catch (error) {
+    if (isFileMissingError(error) || error instanceof SyntaxError)
+      return undefined;
+    throw error;
+  }
+}
+
 function isFileMissingError(error: unknown): boolean {
+  return isErrorWithCode(error, "ENOENT");
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return isErrorWithCode(error, "EEXIST");
+}
+
+function isErrorWithCode(error: unknown, code: string): boolean {
   return (
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    error.code === "ENOENT"
+    error.code === code
   );
 }
 

--- a/packages/state/src/state.ts
+++ b/packages/state/src/state.ts
@@ -32,8 +32,8 @@ export interface StateBackend {
    */
   update(
     id: string,
-    patch: Partial<StateNode>,
     expectedRev: number,
+    patch: Partial<StateNode>,
   ): Promise<{ rev: number }>;
   delete(id: string, expectedRev: number): Promise<void>;
   values(): Promise<StateNode[]>;
@@ -69,8 +69,8 @@ export class MemoryStateBackend implements StateBackend {
 
   async update(
     id: string,
-    patch: Partial<StateNode>,
     expectedRev: number,
+    patch: Partial<StateNode>,
   ): Promise<{ rev: number }> {
     const state = await this.readState();
     assertExpectedRev(id, state[id], expectedRev);
@@ -176,8 +176,8 @@ export class FileStateBackend implements StateBackend {
 
   async update(
     id: string,
-    patch: Partial<StateNode>,
     expectedRev: number,
+    patch: Partial<StateNode>,
   ): Promise<{ rev: number }> {
     return this.withLock(async () => {
       const state = await this.readState();

--- a/packages/state/test/state-backend.test.ts
+++ b/packages/state/test/state-backend.test.ts
@@ -19,6 +19,7 @@ function createStateNode(
   overrides: Partial<StateNode> = {},
 ): StateNode {
   return {
+    rev: 0,
     id,
     groupId: 1,
     groupType: "stack",
@@ -54,16 +55,66 @@ function runStateBackendContractTests(
       const initialNode = createStateNode("resource-a");
 
       try {
-        await fixture.backend.update(initialNode.id, initialNode);
-        await fixture.backend.update(initialNode.id, {
-          output: { status: "ready" },
-          lastOperation: "update",
-        });
+        await fixture.backend.update(initialNode.id, initialNode, 0);
+        await fixture.backend.update(
+          initialNode.id,
+          {
+            output: { status: "ready" },
+            lastOperation: "update",
+          },
+          1,
+        );
 
         await expect(fixture.backend.get(initialNode.id)).resolves.toEqual({
           ...initialNode,
+          rev: 2,
           output: { status: "ready" },
           lastOperation: "update",
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it("rejects stale updates and deletes", async () => {
+      const fixture = await createBackend();
+      const initialNode = createStateNode("resource-a");
+
+      try {
+        await expect(
+          fixture.backend.update(initialNode.id, initialNode, 0),
+        ).resolves.toEqual({ rev: 1 });
+        await expect(
+          fixture.backend.update(initialNode.id, { output: {} }, 0),
+        ).rejects.toMatchObject({
+          name: "RevConflict",
+          expectedRev: 0,
+          actualRev: 1,
+        });
+        await expect(
+          fixture.backend.delete(initialNode.id, 0),
+        ).rejects.toMatchObject({
+          name: "RevConflict",
+        });
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it("treats expectedRev 0 as an expect-absent assertion", async () => {
+      const fixture = await createBackend();
+      const initialNode = createStateNode("resource-a");
+
+      try {
+        await expect(
+          fixture.backend.update(initialNode.id, initialNode, 0),
+        ).resolves.toEqual({ rev: 1 });
+        await expect(
+          fixture.backend.update(initialNode.id, initialNode, 0),
+        ).rejects.toMatchObject({
+          name: "RevConflict",
+          expectedRev: 0,
+          actualRev: 1,
         });
       } finally {
         await fixture.cleanup();
@@ -75,8 +126,8 @@ function runStateBackendContractTests(
       const initialNode = createStateNode("resource-a");
 
       try {
-        await fixture.backend.update(initialNode.id, initialNode);
-        await fixture.backend.delete(initialNode.id);
+        await fixture.backend.update(initialNode.id, initialNode, 0);
+        await fixture.backend.delete(initialNode.id, 1);
 
         await expect(
           fixture.backend.get(initialNode.id),
@@ -94,13 +145,39 @@ function runStateBackendContractTests(
       const secondNode = createStateNode("resource-b");
 
       try {
-        await fixture.backend.update(firstNode.id, firstNode);
-        await fixture.backend.update(secondNode.id, secondNode);
+        await fixture.backend.update(firstNode.id, firstNode, 0);
+        await fixture.backend.update(secondNode.id, secondNode, 0);
 
         const values = await fixture.backend.values();
 
         expect(values).toHaveLength(2);
-        expect(values).toEqual(expect.arrayContaining([firstNode, secondNode]));
+        expect(values).toEqual(
+          expect.arrayContaining([
+            { ...firstNode, rev: 1 },
+            { ...secondNode, rev: 1 },
+          ]),
+        );
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it("holds and renews an exclusive lease", async () => {
+      const fixture = await createBackend();
+
+      try {
+        const lease = await fixture.backend.lease("resource:a", 1_000);
+        const firstExpiry = lease.expiresAt;
+        await expect(
+          fixture.backend.lease("resource:a", 1_000),
+        ).rejects.toMatchObject({ name: "LeaseConflict" });
+
+        await lease.renew(2_000);
+        expect(lease.expiresAt).not.toBe(firstExpiry);
+        await lease.release();
+
+        const next = await fixture.backend.lease("resource:a", 1_000);
+        await next.release();
       } finally {
         await fixture.cleanup();
       }
@@ -121,15 +198,50 @@ runStateBackendContractTests("MemoryStateBackend", async () => ({
   cleanup: async () => undefined,
 }));
 
+describe("FileStateBackend", () => {
+  it("serialises concurrent CAS writers so only one wins", async () => {
+    const tempDirectory = await mkdtemp(path.join(tmpdir(), "notation-state-"));
+    const statePath = path.join(tempDirectory, "state.json");
+    const first = new FileStateBackend(statePath);
+    const second = new FileStateBackend(statePath);
+    const initialNode = createStateNode("resource-a");
+
+    try {
+      await first.update(initialNode.id, initialNode, 0);
+
+      const results = await Promise.allSettled([
+        first.update(initialNode.id, { output: { writer: "first" } }, 1),
+        second.update(initialNode.id, { output: { writer: "second" } }, 1),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+        name: "RevConflict",
+      });
+      await expect(first.get(initialNode.id)).resolves.toMatchObject({
+        rev: 2,
+      });
+    } finally {
+      await rm(tempDirectory, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("MemoryStateBackend", () => {
   it("returns values in deterministic id order", async () => {
     const backend = new MemoryStateBackend();
     const laterNode = createStateNode("resource-z");
     const earlierNode = createStateNode("resource-a");
 
-    await backend.update(laterNode.id, laterNode);
-    await backend.update(earlierNode.id, earlierNode);
+    await backend.update(laterNode.id, laterNode, 0);
+    await backend.update(earlierNode.id, earlierNode, 0);
 
-    await expect(backend.values()).resolves.toEqual([earlierNode, laterNode]);
+    await expect(backend.values()).resolves.toEqual([
+      { ...earlierNode, rev: 1 },
+      { ...laterNode, rev: 1 },
+    ]);
   });
 });

--- a/packages/state/test/state-backend.test.ts
+++ b/packages/state/test/state-backend.test.ts
@@ -55,15 +55,11 @@ function runStateBackendContractTests(
       const initialNode = createStateNode("resource-a");
 
       try {
-        await fixture.backend.update(initialNode.id, initialNode, 0);
-        await fixture.backend.update(
-          initialNode.id,
-          {
-            output: { status: "ready" },
-            lastOperation: "update",
-          },
-          1,
-        );
+        await fixture.backend.update(initialNode.id, 0, initialNode);
+        await fixture.backend.update(initialNode.id, 1, {
+          output: { status: "ready" },
+          lastOperation: "update",
+        });
 
         await expect(fixture.backend.get(initialNode.id)).resolves.toEqual({
           ...initialNode,
@@ -82,10 +78,10 @@ function runStateBackendContractTests(
 
       try {
         await expect(
-          fixture.backend.update(initialNode.id, initialNode, 0),
+          fixture.backend.update(initialNode.id, 0, initialNode),
         ).resolves.toEqual({ rev: 1 });
         await expect(
-          fixture.backend.update(initialNode.id, { output: {} }, 0),
+          fixture.backend.update(initialNode.id, 0, { output: {} }),
         ).rejects.toMatchObject({
           name: "RevConflict",
           expectedRev: 0,
@@ -107,10 +103,10 @@ function runStateBackendContractTests(
 
       try {
         await expect(
-          fixture.backend.update(initialNode.id, initialNode, 0),
+          fixture.backend.update(initialNode.id, 0, initialNode),
         ).resolves.toEqual({ rev: 1 });
         await expect(
-          fixture.backend.update(initialNode.id, initialNode, 0),
+          fixture.backend.update(initialNode.id, 0, initialNode),
         ).rejects.toMatchObject({
           name: "RevConflict",
           expectedRev: 0,
@@ -126,7 +122,7 @@ function runStateBackendContractTests(
       const initialNode = createStateNode("resource-a");
 
       try {
-        await fixture.backend.update(initialNode.id, initialNode, 0);
+        await fixture.backend.update(initialNode.id, 0, initialNode);
         await fixture.backend.delete(initialNode.id, 1);
 
         await expect(
@@ -145,8 +141,8 @@ function runStateBackendContractTests(
       const secondNode = createStateNode("resource-b");
 
       try {
-        await fixture.backend.update(firstNode.id, firstNode, 0);
-        await fixture.backend.update(secondNode.id, secondNode, 0);
+        await fixture.backend.update(firstNode.id, 0, firstNode);
+        await fixture.backend.update(secondNode.id, 0, secondNode);
 
         const values = await fixture.backend.values();
 
@@ -207,11 +203,11 @@ describe("FileStateBackend", () => {
     const initialNode = createStateNode("resource-a");
 
     try {
-      await first.update(initialNode.id, initialNode, 0);
+      await first.update(initialNode.id, 0, initialNode);
 
       const results = await Promise.allSettled([
-        first.update(initialNode.id, { output: { writer: "first" } }, 1),
-        second.update(initialNode.id, { output: { writer: "second" } }, 1),
+        first.update(initialNode.id, 1, { output: { writer: "first" } }),
+        second.update(initialNode.id, 1, { output: { writer: "second" } }),
       ]);
 
       const fulfilled = results.filter((r) => r.status === "fulfilled");
@@ -236,8 +232,8 @@ describe("MemoryStateBackend", () => {
     const laterNode = createStateNode("resource-z");
     const earlierNode = createStateNode("resource-a");
 
-    await backend.update(laterNode.id, laterNode, 0);
-    await backend.update(earlierNode.id, earlierNode, 0);
+    await backend.update(laterNode.id, 0, laterNode);
+    await backend.update(earlierNode.id, 0, earlierNode);
 
     await expect(backend.values()).resolves.toEqual([
       { ...earlierNode, rev: 1 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       '@notation/state':
         specifier: workspace:*
         version: link:../state
+      '@notation/state-sqlite':
+        specifier: workspace:*
+        version: link:../state-sqlite
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
@@ -330,6 +333,16 @@ importers:
   packages/resource: {}
 
   packages/state:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.13.4
+
+  packages/state-sqlite:
+    dependencies:
+      '@notation/state':
+        specifier: workspace:*
+        version: link:../state
     devDependencies:
       '@types/node':
         specifier: ^22.13.4


### PR DESCRIPTION
## Summary

Add revisioned state writes, renewable leases, and a SQLite state backend.

The reconciler uses resource leases and compare-and-swap writes to coordinate concurrent mutations. Orphan deletion is serialised through its own lease. The file, memory, and SQLite backends implement the same state contract.

Every mutation must provide the revision it observed. Revision `0` asserts that the resource does not exist. SQLite stores resources and their leases in the `resources` and `resource_leases` tables.

## Stack

Depends on #26. The PR base points at that branch so this diff contains only state and concurrency work.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:once` – 97 passed, 4 skipped
