### PR TITLE
Unify CLI logging

### DIFF
--- a/packages/cli/src/compile.ts
+++ b/packages/cli/src/compile.ts
@@ -1,18 +1,26 @@
 import chokidar from "chokidar";
 import { glob } from "glob";
-import { log } from "console";
 import esbuild from "esbuild";
 import {
   functionInfraPlugin,
   functionRuntimePlugin,
 } from "@notation/esbuild-plugins";
 import { filePaths } from "@notation/core";
+import { defaultLogger, type Logger } from "./logger";
 
-export async function compile(entryPoint: string, watch: boolean = false) {
-  log(`${watch ? "Watching" : "Compiling"} infrastructure`, entryPoint);
+export type CompileOptions = {
+  watch?: boolean;
+  logger?: Logger;
+};
+
+export async function compile(entryPoint: string, opts: CompileOptions = {}) {
+  const watch = opts.watch ?? false;
+  const logger = opts.logger ?? defaultLogger;
+
+  logger.info(`${watch ? "Watching" : "Compiling"} infrastructure`, entryPoint);
   await compileInfra(entryPoint, watch);
 
-  log(`${watch ? "Watching" : "Compiling"} functions`);
+  logger.info(`${watch ? "Watching" : "Compiling"} functions`);
 
   // @todo: fnEntryPoints could be an output of compileInfra
   const fnEntryPoints = await glob("runtime/**/*.fn.ts");

--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -1,23 +1,30 @@
-import { createNdjsonEventEmitter, deployApp } from "@notation/core";
+import {
+  createLoggerReconcilerSubscriber,
+  createNdjsonEventEmitter,
+  deployApp,
+} from "@notation/core";
 import { compile } from "./compile";
+import { defaultLogger, type Logger } from "./logger";
 import { redirectStdoutToStderr } from "./stdio";
 
 export type DeployCommandOptions = {
   json?: boolean;
+  logger?: Logger;
 };
 
 export async function deploy(
   entryPoint: string,
   opts: DeployCommandOptions = {},
 ) {
+  const logger = opts.logger ?? defaultLogger;
   // In --json mode console output moves to stderr so stdout carries only the
   // NDJSON event stream; capture the real stdout for the emitter first.
   const emit = opts.json
     ? createNdjsonEventEmitter(redirectStdoutToStderr().write)
-    : undefined;
+    : createLoggerReconcilerSubscriber({ logger });
 
-  await compile(entryPoint);
-  console.log(`Deploying ${entryPoint}`);
+  await compile(entryPoint, { logger });
+  logger.info(`Deploying ${entryPoint}`);
 
   try {
     await deployApp(
@@ -30,14 +37,14 @@ export async function deploy(
     );
   } catch (err: any) {
     if (err.name === "CredentialsProviderError") {
-      console.log(
+      logger.error(
         "\nAWS credentials not found.",
         "\n\nEnsure you have a default profile set up in ~/.aws/credentials.",
         "\n\nIf using another profile run AWS_PROFILE=otherProfile notation deploy.\n",
       );
       process.exit(1);
     }
-    console.log(err);
+    logger.error(err);
     process.exit(1);
   }
 }

--- a/packages/cli/src/destroy.ts
+++ b/packages/cli/src/destroy.ts
@@ -1,19 +1,27 @@
-import { createNdjsonEventEmitter, destroyApp } from "@notation/core";
+import {
+  createLoggerReconcilerSubscriber,
+  createNdjsonEventEmitter,
+  destroyApp,
+} from "@notation/core";
 import { compile } from "./compile";
+import { defaultLogger, type Logger } from "./logger";
 import { redirectStdoutToStderr } from "./stdio";
 
 export type DestroyCommandOptions = {
   json?: boolean;
+  logger?: Logger;
 };
 
 export async function destroy(
   entryPoint: string,
   opts: DestroyCommandOptions = {},
 ) {
+  const logger = opts.logger ?? defaultLogger;
   const emit = opts.json
     ? createNdjsonEventEmitter(redirectStdoutToStderr().write)
-    : undefined;
+    : createLoggerReconcilerSubscriber({ logger });
 
-  await compile(entryPoint);
+  await compile(entryPoint, { logger });
+  logger.info(`Destroying ${entryPoint}\n`);
   await destroyApp(entryPoint, undefined, undefined, emit);
 }

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -1,0 +1,5 @@
+import type { Logger } from "@notation/core";
+
+export const defaultLogger: Logger = console;
+
+export type { Logger };

--- a/packages/cli/src/plan.ts
+++ b/packages/cli/src/plan.ts
@@ -1,9 +1,16 @@
-import { planApp, type Plan, type PlanNode } from "@notation/core";
+import {
+  createLoggerReconcilerSubscriber,
+  planApp,
+  type Plan,
+  type PlanNode,
+} from "@notation/core";
 import { compile } from "./compile";
+import { defaultLogger, type Logger } from "./logger";
 import { redirectStdoutToStderr } from "./stdio";
 
 export type PlanCommandOptions = {
   json?: boolean;
+  logger?: Logger;
 };
 
 const decisionSymbols: Record<PlanNode["decision"], string> = {
@@ -16,13 +23,21 @@ const decisionSymbols: Record<PlanNode["decision"], string> = {
 };
 
 export async function plan(entryPoint: string, opts: PlanCommandOptions = {}) {
+  const logger = opts.logger ?? defaultLogger;
+  const emit = createLoggerReconcilerSubscriber({ logger });
   try {
     if (opts.json) {
       let result: Plan;
       const { restore } = redirectStdoutToStderr();
       try {
-        await compile(entryPoint);
-        result = await planApp(entryPoint);
+        await compile(entryPoint, { logger });
+        result = await planApp(
+          entryPoint,
+          undefined,
+          undefined,
+          undefined,
+          emit,
+        );
       } finally {
         restore();
       }
@@ -30,13 +45,19 @@ export async function plan(entryPoint: string, opts: PlanCommandOptions = {}) {
       return;
     }
 
-    await compile(entryPoint);
-    console.log(`Planning ${entryPoint}\n`);
-    const result = await planApp(entryPoint);
-    printPlanSummary(result);
+    await compile(entryPoint, { logger });
+    logger.info(`Planning ${entryPoint}\n`);
+    const result = await planApp(
+      entryPoint,
+      undefined,
+      undefined,
+      undefined,
+      emit,
+    );
+    printPlanSummary(result, logger);
   } catch (err: any) {
     if (err.name === "CredentialsProviderError") {
-      console.log(
+      logger.error(
         "\nAWS credentials not found.",
         "\n\nEnsure you have a default profile set up in ~/.aws/credentials.",
         "\n\nIf using another profile run AWS_PROFILE=otherProfile notation plan.\n",
@@ -47,11 +68,11 @@ export async function plan(entryPoint: string, opts: PlanCommandOptions = {}) {
   }
 }
 
-function printPlanSummary(result: Plan) {
+function printPlanSummary(result: Plan, logger: Logger) {
   const changedNodes = result.nodes.filter((node) => node.decision !== "noop");
 
   for (const node of changedNodes) {
-    console.log(
+    logger.info(
       `${decisionSymbols[node.decision]} ${node.decision} ${node.type} ${node.id}`,
     );
   }
@@ -67,5 +88,5 @@ function printPlanSummary(result: Plan) {
     `${count("noop")} unchanged`,
   ].join(", ");
 
-  console.log(`${changedNodes.length > 0 ? "\n" : ""}Plan: ${summary}.`);
+  logger.info(`${changedNodes.length > 0 ? "\n" : ""}Plan: ${summary}.`);
 }

--- a/packages/cli/src/visualise.ts
+++ b/packages/cli/src/visualise.ts
@@ -3,21 +3,27 @@ import {
   createMermaidLiveUrl,
   getResourceGraph,
 } from "@notation/core";
-import { log } from "console";
 import { compileInfra } from "./compile";
+import { defaultLogger, type Logger } from "./logger";
 
-export async function visualise(entryPoint: string) {
+export async function visualise(
+  entryPoint: string,
+  logger: Logger = defaultLogger,
+) {
   await compileInfra(entryPoint);
-  await generateGraph(entryPoint);
+  await generateGraph(entryPoint, logger);
 }
 
-export async function generateGraph(entryPoint: string) {
-  log(`Generating graph for ${entryPoint}`);
+export async function generateGraph(
+  entryPoint: string,
+  logger: Logger = defaultLogger,
+) {
+  logger.info(`Generating graph for ${entryPoint}`);
 
   const graph = await getResourceGraph(entryPoint);
   const chart = createMermaidFlowChart(graph.resourceGroups, graph.resources);
   const chartUrl = createMermaidLiveUrl(chart);
 
-  log("\nGenerated infrastructure chart:\n");
-  log(chartUrl);
+  logger.info("\nGenerated infrastructure chart:\n");
+  logger.info(chartUrl);
 }

--- a/packages/cli/src/watch.ts
+++ b/packages/cli/src/watch.ts
@@ -1,11 +1,15 @@
 import chokidar from "chokidar";
-import { deployApp } from "@notation/core";
+import { createLoggerReconcilerSubscriber, deployApp } from "@notation/core";
 import { compile } from "./compile";
+import { defaultLogger, type Logger } from "./logger";
 
 const dotFilesRe = /(^|[\/\\])\../;
 
-export async function watch(entryPoint: string) {
-  await compile(entryPoint, true);
+export async function watch(
+  entryPoint: string,
+  logger: Logger = defaultLogger,
+) {
+  await compile(entryPoint, { watch: true, logger });
 
   const watcher = chokidar.watch("dist", {
     ignored: dotFilesRe,
@@ -36,7 +40,14 @@ export async function watch(entryPoint: string) {
 
     isDeploying = true;
 
-    deployApp(entryPoint, false)
+    deployApp(
+      entryPoint,
+      false,
+      undefined,
+      undefined,
+      undefined,
+      createLoggerReconcilerSubscriber({ logger }),
+    )
       .then(() => {
         isDeploying = false;
         if (deployQueued) {
@@ -45,7 +56,7 @@ export async function watch(entryPoint: string) {
         }
       })
       .catch((err) => {
-        console.error(err);
+        logger.error(err);
         isDeploying = false;
       });
   }

--- a/packages/core/src/provisioner/workflows/index.ts
+++ b/packages/core/src/provisioner/workflows/index.ts
@@ -1,6 +1,7 @@
 export {
-  createConsoleReconcilerSubscriber,
+  createLoggerReconcilerSubscriber,
   createNdjsonEventEmitter,
+  type Logger,
   type ReconcilerEventEmitter,
 } from "@notation/reconciler";
 export * from "./workflow.deploy";

--- a/packages/core/src/provisioner/workflows/workflow.deploy.ts
+++ b/packages/core/src/provisioner/workflows/workflow.deploy.ts
@@ -1,6 +1,6 @@
 import {
   Reconciler,
-  createConsoleReconcilerSubscriber,
+  createLoggerReconcilerSubscriber,
   type ReconcilerEventEmitter,
   type ResourceRegistry,
 } from "@notation/reconciler";
@@ -14,7 +14,7 @@ export async function deployApp(
   dryRun = false,
   registry?: ResourceRegistry,
   stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createConsoleReconcilerSubscriber(),
+  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
 ): Promise<void> {
   const graph = await getResourceGraph(entryPoint);
   const state = stateBackend ?? createDefaultStateBackend();

--- a/packages/core/src/provisioner/workflows/workflow.destroy.ts
+++ b/packages/core/src/provisioner/workflows/workflow.destroy.ts
@@ -1,6 +1,6 @@
 import {
   Reconciler,
-  createConsoleReconcilerSubscriber,
+  createLoggerReconcilerSubscriber,
   type ReconcilerEventEmitter,
   type ResourceRegistry,
 } from "@notation/reconciler";
@@ -13,10 +13,8 @@ export async function destroyApp(
   entryPoint: string,
   registry?: ResourceRegistry,
   stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createConsoleReconcilerSubscriber(),
+  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
 ) {
-  console.log(`Destroying ${entryPoint}\n`);
-
   const state = stateBackend ?? createDefaultStateBackend();
 
   await refreshState(entryPoint, false, registry, state, emit);

--- a/packages/core/src/provisioner/workflows/workflow.plan.ts
+++ b/packages/core/src/provisioner/workflows/workflow.plan.ts
@@ -1,6 +1,6 @@
 import {
   Reconciler,
-  createConsoleReconcilerSubscriber,
+  createLoggerReconcilerSubscriber,
   type Plan,
   type ReconcilerEventEmitter,
   type ResourceRegistry,
@@ -16,7 +16,7 @@ export async function planApp(
   driftDetection = true,
   registry?: ResourceRegistry,
   stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createConsoleReconcilerSubscriber(),
+  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
 ): Promise<Plan> {
   const graph = await getResourceGraph(entryPoint);
   const state = stateBackend ?? createDefaultStateBackend();

--- a/packages/core/src/provisioner/workflows/workflow.refresh.ts
+++ b/packages/core/src/provisioner/workflows/workflow.refresh.ts
@@ -1,6 +1,6 @@
 import {
   Reconciler,
-  createConsoleReconcilerSubscriber,
+  createLoggerReconcilerSubscriber,
   type ReconcilerEventEmitter,
   type ResourceRegistry,
 } from "@notation/reconciler";
@@ -16,10 +16,8 @@ export async function refreshState(
   dryRun = false,
   registry?: ResourceRegistry,
   stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createConsoleReconcilerSubscriber(),
+  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
 ): Promise<void> {
-  console.log(`${dryRun ? "[Dry Run]: " : ""}Refreshing ${entryPoint} state\n`);
-
   const graph = await getResourceGraph(entryPoint);
   const state = stateBackend ?? createDefaultStateBackend();
 

--- a/packages/reconciler/src/index.ts
+++ b/packages/reconciler/src/index.ts
@@ -8,5 +8,5 @@ export * from "./operations";
 export * from "./dependency-graph";
 export * from "./plan";
 export * from "./reconciler";
-export * from "./console-subscriber";
+export * from "./logger-subscriber";
 export * from "./protocol";

--- a/packages/reconciler/src/logger-subscriber.ts
+++ b/packages/reconciler/src/logger-subscriber.ts
@@ -1,15 +1,15 @@
 import type { ReconcilerEvent, ReconcilerEventEmitter } from "./reconciler";
 
-export type ConsoleLike = Pick<Console, "info" | "warn" | "error">;
+export type Logger = Pick<Console, "info" | "warn" | "error">;
 
-export type ConsoleReconcilerSubscriberOptions = {
-  console?: ConsoleLike;
+export type LoggerReconcilerSubscriberOptions = {
+  logger?: Logger;
 };
 
-export function createConsoleReconcilerSubscriber(
-  opts: ConsoleReconcilerSubscriberOptions = {},
+export function createLoggerReconcilerSubscriber(
+  opts: LoggerReconcilerSubscriberOptions = {},
 ): ReconcilerEventEmitter {
-  const logger = opts.console ?? console;
+  const logger = opts.logger ?? console;
 
   return async (event: ReconcilerEvent) => {
     if (event.level === "error") {

--- a/packages/reconciler/test/logger-subscriber.test.ts
+++ b/packages/reconciler/test/logger-subscriber.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { createConsoleReconcilerSubscriber } from "../src";
+import { createLoggerReconcilerSubscriber } from "../src";
 
-describe("console reconciler subscriber", () => {
-  it("routes info, warning, and error events to matching console methods", async () => {
+describe("logger reconciler subscriber", () => {
+  it("routes info, warning, and error events to matching logger methods", async () => {
     const info = vi.fn();
     const warn = vi.fn();
     const error = vi.fn();
 
-    const emit = createConsoleReconcilerSubscriber({
-      console: { info, warn, error },
+    const emit = createLoggerReconcilerSubscriber({
+      logger: { info, warn, error },
     });
 
     await emit({


### PR DESCRIPTION
Notation's first-party output now goes through a shared `Logger` contract. CLI commands inject that logger into compilation, summaries, errors, watch mode, and reconciler events. Core workflows no longer write headings directly.

The reconciler adapter is now `createLoggerReconcilerSubscriber`. The previous console-specific API has been removed.

`redirectStdoutToStderr` remains at the JSON protocol boundary. Resource graph evaluation still imports user code in-process, so userland `console.log` calls must be kept away from stdout.

## Checks

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:once`
