### PR TITLE
Use options objects for app workflows

### DIFF
--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -27,14 +27,10 @@ export async function deploy(
   logger.info(`Deploying ${entryPoint}`);
 
   try {
-    await deployApp(
+    await deployApp({
       entryPoint,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
       emit,
-    );
+    });
   } catch (err: any) {
     if (err.name === "CredentialsProviderError") {
       logger.error(

--- a/packages/cli/src/destroy.ts
+++ b/packages/cli/src/destroy.ts
@@ -23,5 +23,5 @@ export async function destroy(
 
   await compile(entryPoint, { logger });
   logger.info(`Destroying ${entryPoint}\n`);
-  await destroyApp(entryPoint, undefined, undefined, emit);
+  await destroyApp({ entryPoint, emit });
 }

--- a/packages/cli/src/plan.ts
+++ b/packages/cli/src/plan.ts
@@ -31,13 +31,10 @@ export async function plan(entryPoint: string, opts: PlanCommandOptions = {}) {
       const { restore } = redirectStdoutToStderr();
       try {
         await compile(entryPoint, { logger });
-        result = await planApp(
+        result = await planApp({
           entryPoint,
-          undefined,
-          undefined,
-          undefined,
           emit,
-        );
+        });
       } finally {
         restore();
       }
@@ -47,13 +44,10 @@ export async function plan(entryPoint: string, opts: PlanCommandOptions = {}) {
 
     await compile(entryPoint, { logger });
     logger.info(`Planning ${entryPoint}\n`);
-    const result = await planApp(
+    const result = await planApp({
       entryPoint,
-      undefined,
-      undefined,
-      undefined,
       emit,
-    );
+    });
     printPlanSummary(result, logger);
   } catch (err: any) {
     if (err.name === "CredentialsProviderError") {

--- a/packages/cli/src/watch.ts
+++ b/packages/cli/src/watch.ts
@@ -40,14 +40,11 @@ export async function watch(
 
     isDeploying = true;
 
-    deployApp(
+    deployApp({
       entryPoint,
-      false,
-      undefined,
-      undefined,
-      undefined,
-      createLoggerReconcilerSubscriber({ logger }),
-    )
+      driftDetection: false,
+      emit: createLoggerReconcilerSubscriber({ logger }),
+    })
       .then(() => {
         isDeploying = false;
         if (deployQueued) {

--- a/packages/core/src/provisioner/workflows/workflow.deploy.ts
+++ b/packages/core/src/provisioner/workflows/workflow.deploy.ts
@@ -8,14 +8,23 @@ import type { StateBackend } from "@notation/state";
 import { getResourceGraph } from "src/orchestrator/graph";
 import { createDefaultStateBackend } from "../state-backend";
 
-export async function deployApp(
-  entryPoint: string,
+export type DeployAppOptions = {
+  entryPoint: string;
+  driftDetection?: boolean;
+  dryRun?: boolean;
+  registry?: ResourceRegistry;
+  state?: StateBackend;
+  emit?: ReconcilerEventEmitter;
+};
+
+export async function deployApp({
+  entryPoint,
   driftDetection = true,
   dryRun = false,
-  registry?: ResourceRegistry,
-  stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
-): Promise<void> {
+  registry,
+  state: stateBackend,
+  emit = createLoggerReconcilerSubscriber(),
+}: DeployAppOptions): Promise<void> {
   const graph = await getResourceGraph(entryPoint);
   const state = stateBackend ?? createDefaultStateBackend();
   const reconciler = new Reconciler({

--- a/packages/core/src/provisioner/workflows/workflow.destroy.ts
+++ b/packages/core/src/provisioner/workflows/workflow.destroy.ts
@@ -9,15 +9,21 @@ import { getResourceGraph } from "src/orchestrator/graph";
 import { createDefaultStateBackend } from "../state-backend";
 import { refreshState } from "./workflow.refresh";
 
-export async function destroyApp(
-  entryPoint: string,
-  registry?: ResourceRegistry,
-  stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
-) {
-  const state = stateBackend ?? createDefaultStateBackend();
+export type DestroyAppOptions = {
+  entryPoint: string;
+  registry?: ResourceRegistry;
+  state?: StateBackend;
+  emit?: ReconcilerEventEmitter;
+};
 
-  await refreshState(entryPoint, false, registry, state, emit);
+export async function destroyApp({
+  entryPoint,
+  registry,
+  state: stateBackend,
+  emit = createLoggerReconcilerSubscriber(),
+}: DestroyAppOptions) {
+  const state = stateBackend ?? createDefaultStateBackend();
+  await refreshState({ entryPoint, registry, state, emit });
 
   const graph = await getResourceGraph(entryPoint);
   const reconciler = new Reconciler({

--- a/packages/core/src/provisioner/workflows/workflow.plan.ts
+++ b/packages/core/src/provisioner/workflows/workflow.plan.ts
@@ -11,13 +11,21 @@ import { createDefaultStateBackend } from "../state-backend";
 
 export type { Plan, PlanNode, PlanDecision } from "@notation/reconciler";
 
-export async function planApp(
-  entryPoint: string,
+export type PlanAppOptions = {
+  entryPoint: string;
+  driftDetection?: boolean;
+  registry?: ResourceRegistry;
+  state?: StateBackend;
+  emit?: ReconcilerEventEmitter;
+};
+
+export async function planApp({
+  entryPoint,
   driftDetection = true,
-  registry?: ResourceRegistry,
-  stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
-): Promise<Plan> {
+  registry,
+  state: stateBackend,
+  emit = createLoggerReconcilerSubscriber(),
+}: PlanAppOptions): Promise<Plan> {
   const graph = await getResourceGraph(entryPoint);
   const state = stateBackend ?? createDefaultStateBackend();
   const reconciler = new Reconciler({

--- a/packages/core/src/provisioner/workflows/workflow.refresh.ts
+++ b/packages/core/src/provisioner/workflows/workflow.refresh.ts
@@ -11,13 +11,21 @@ import { createDefaultStateBackend } from "../state-backend";
 /**
  * @description Destroy resources that are in state but not in the orchestration graph
  */
-export async function refreshState(
-  entryPoint: string,
+export type RefreshStateOptions = {
+  entryPoint: string;
+  dryRun?: boolean;
+  registry?: ResourceRegistry;
+  state?: StateBackend;
+  emit?: ReconcilerEventEmitter;
+};
+
+export async function refreshState({
+  entryPoint,
   dryRun = false,
-  registry?: ResourceRegistry,
-  stateBackend?: StateBackend,
-  emit: ReconcilerEventEmitter = createLoggerReconcilerSubscriber(),
-): Promise<void> {
+  registry,
+  state: stateBackend,
+  emit = createLoggerReconcilerSubscriber(),
+}: RefreshStateOptions): Promise<void> {
   const graph = await getResourceGraph(entryPoint);
   const state = stateBackend ?? createDefaultStateBackend();
 


### PR DESCRIPTION
The core app workflows now accept one options object:

- `deployApp`
- `destroyApp`
- `planApp`
- `refreshState`

The old positional signatures have been removed. Callers can name the state backend, registry, emitter, and execution flags without passing placeholder `undefined` values.

This PR is stacked on the logging PR because both changes update the CLI workflow call sites.

## Checks

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:once`
