### PR TITLE
Finalize Yieldstar integration error handling

### DIFF
--- a/packages/cli/src/deploy.ts
+++ b/packages/cli/src/deploy.ts
@@ -7,7 +7,6 @@ import { randomUUID } from "node:crypto";
 import { compile } from "./compile";
 import { defaultLogger, type Logger } from "./logger";
 import { redirectStdoutToStderr } from "./stdio";
-import { runWithCliErrorHandling } from "./run-with-error-handling";
 
 export type DeployCommandOptions = {
   json?: boolean;
@@ -29,8 +28,5 @@ export async function deploy(
   const executionId = opts.executionId ?? randomUUID();
   logger.info(`Yieldstar execution ${executionId}`);
 
-  await runWithCliErrorHandling(
-    () => deployApp({ entryPoint, emit, executionId }),
-    { logger, command: "deploy" },
-  );
+  await deployApp({ entryPoint, emit, executionId });
 }

--- a/packages/cli/src/destroy.ts
+++ b/packages/cli/src/destroy.ts
@@ -7,7 +7,6 @@ import { randomUUID } from "node:crypto";
 import { compile } from "./compile";
 import { defaultLogger, type Logger } from "./logger";
 import { redirectStdoutToStderr } from "./stdio";
-import { runWithCliErrorHandling } from "./run-with-error-handling";
 
 export type DestroyCommandOptions = {
   json?: boolean;
@@ -29,8 +28,5 @@ export async function destroy(
   const executionId = opts.executionId ?? randomUUID();
   logger.info(`Yieldstar execution ${executionId}`);
 
-  await runWithCliErrorHandling(
-    () => destroyApp({ entryPoint, emit, executionId }),
-    { logger, command: "destroy" },
-  );
+  await destroyApp({ entryPoint, emit, executionId });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,8 @@ import { compile } from "./compile";
 import { deploy } from "./deploy";
 import { destroy } from "./destroy";
 import { plan } from "./plan";
+import { defaultLogger } from "./logger";
+import { runWithCliErrorHandling } from "./run-with-error-handling";
 import { visualise } from "./visualise";
 import { watch } from "./watch";
 import { startDashboardServer } from "@notation/dashboard";
@@ -77,4 +79,7 @@ program
     await watch(entryPoint);
   });
 
-program.parse(process.argv);
+process.exitCode = await runWithCliErrorHandling(
+  () => program.parseAsync(process.argv),
+  { logger: defaultLogger, command: process.argv[2] ?? program.name() },
+);

--- a/packages/cli/src/plan.ts
+++ b/packages/cli/src/plan.ts
@@ -19,39 +19,27 @@ const decisionSymbols: Record<PlanNode["decision"], string> = {
 
 export async function plan(entryPoint: string, opts: PlanCommandOptions = {}) {
   const logger = opts.logger ?? defaultLogger;
-  try {
-    if (opts.json) {
-      let result: Plan;
-      const { restore } = redirectStdoutToStderr();
-      try {
-        await compile(entryPoint, { logger });
-        result = await planApp({
-          entryPoint,
-        });
-      } finally {
-        restore();
-      }
-      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-      return;
+  if (opts.json) {
+    let result: Plan;
+    const { restore } = redirectStdoutToStderr();
+    try {
+      await compile(entryPoint, { logger });
+      result = await planApp({
+        entryPoint,
+      });
+    } finally {
+      restore();
     }
-
-    await compile(entryPoint, { logger });
-    logger.info(`Planning ${entryPoint}\n`);
-    const result = await planApp({
-      entryPoint,
-    });
-    printPlanSummary(result, logger);
-  } catch (err: any) {
-    if (err.name === "CredentialsProviderError") {
-      logger.error(
-        "\nAWS credentials not found.",
-        "\n\nEnsure you have a default profile set up in ~/.aws/credentials.",
-        "\n\nIf using another profile run AWS_PROFILE=otherProfile notation plan.\n",
-      );
-      process.exit(1);
-    }
-    throw err;
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
   }
+
+  await compile(entryPoint, { logger });
+  logger.info(`Planning ${entryPoint}\n`);
+  const result = await planApp({
+    entryPoint,
+  });
+  printPlanSummary(result, logger);
 }
 
 function printPlanSummary(result: Plan, logger: Logger) {

--- a/packages/cli/src/run-with-error-handling.ts
+++ b/packages/cli/src/run-with-error-handling.ts
@@ -1,21 +1,22 @@
 import type { Logger } from "./logger";
 
 export async function runWithCliErrorHandling(
-  fn: () => Promise<void>,
+  fn: () => Promise<unknown>,
   opts: { logger: Logger; command: string },
-): Promise<void> {
+): Promise<0 | 1> {
   try {
     await fn();
-  } catch (err: any) {
-    if (err.name === "CredentialsProviderError") {
+    return 0;
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === "CredentialsProviderError") {
       opts.logger.error(
         "\nAWS credentials not found.",
         "\n\nEnsure you have a default profile set up in ~/.aws/credentials.",
         `\n\nIf using another profile run AWS_PROFILE=otherProfile notation ${opts.command}.\n`,
       );
-      process.exit(1);
+      return 1;
     }
-    opts.logger.error(err);
-    process.exit(1);
+    opts.logger.error(error);
+    return 1;
   }
 }

--- a/packages/cli/test/run-with-error-handling.test.ts
+++ b/packages/cli/test/run-with-error-handling.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { runWithCliErrorHandling } from "../src/run-with-error-handling";
+
+describe("CLI error handling", () => {
+  it("reports credential failures with command-specific guidance", async () => {
+    const error = new Error("Could not load credentials");
+    error.name = "CredentialsProviderError";
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const exitCode = await runWithCliErrorHandling(
+      async () => {
+        throw error;
+      },
+      { logger, command: "deploy" },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(
+      "\nAWS credentials not found.",
+      "\n\nEnsure you have a default profile set up in ~/.aws/credentials.",
+      "\n\nIf using another profile run AWS_PROFILE=otherProfile notation deploy.\n",
+    );
+  });
+
+  it("reports non-credential failures unchanged", async () => {
+    const error = new Error("deploy failed");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const exitCode = await runWithCliErrorHandling(
+      async () => {
+        throw error;
+      },
+      { logger, command: "deploy" },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logger.error).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/reconciler/src/logger-subscriber.ts
+++ b/packages/reconciler/src/logger-subscriber.ts
@@ -17,7 +17,7 @@ export function createLoggerReconcilerSubscriber(
       return;
     }
 
-    if (event.event === "reconciler.orphan-deletion.skipped") {
+    if (event.level === "warn") {
       logger.warn(event.event, event);
       return;
     }

--- a/packages/reconciler/test/logger-subscriber.test.ts
+++ b/packages/reconciler/test/logger-subscriber.test.ts
@@ -28,6 +28,13 @@ describe("logger reconciler subscriber", () => {
       resourceType: "test/service/subscriber",
     });
     await emit({
+      level: "warn",
+      event: "reconciler.coordination.waiting",
+      deploymentId: "deployment-1",
+      executionId: "execution-2",
+      holderExecutionId: "execution-1",
+    });
+    await emit({
       level: "error",
       event: "reconciler.operation.lifecycle",
       operation: "delete",
@@ -39,7 +46,12 @@ describe("logger reconciler subscriber", () => {
     });
 
     expect(info).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenNthCalledWith(
+      2,
+      "reconciler.coordination.waiting",
+      expect.objectContaining({ level: "warn" }),
+    );
     expect(error).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- Route reconciler log events by `event.level`, ensuring coordination-waiting and every future warning-level event use `logger.warn`.
- Replace command-local `process.exit(1)` calls with one testable async Commander error boundary that returns the CLI exit status.
- Consolidate plan, deploy, and destroy credential failures through the same command-specific guidance while preserving non-credential error logging.

## Review findings addressed

- Added focused regression coverage for the durable `reconciler.coordination.waiting` warning event.
- Added credential and non-credential command-boundary failure tests.
- Preserved deployment store-prefix isolation, the durable coordination-waiting event, destroy handling, and the existing durable execution, replay, store CAS, coordination, and destroy semantics.
- Confirmed Notation-owned terminology uses Yieldstar; upstream identifiers and package names remain unchanged.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test:once` (79 passed, 4 skipped)
- Focused reconciler logger and CLI error-boundary tests
- Prettier check for all changed source and test files
- `git diff --check`
- Markdown physical-line audit (the stacked implementation diff changes no Markdown files)
- Yieldstar terminology audit

## Upstream release risk (not patched in Notation)

The installed `@yieldstar/sqlite-runtime` 0.5.0 task queue writes `Date.now() + VISIBILITY_WINDOW` milliseconds to `visible_from`, while its SQL visibility queries compare that value with `strftime('%s', 'now')` Unix seconds. If a worker crashes after taking a task, the task can remain hidden for roughly 55,000 years. This requires an upstream release fix; this PR intentionally contains no Notation patch, workaround, fallback, lease, or refresh path.
